### PR TITLE
chore: add HMDA isolation lint to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,7 @@
 pnpm lint-staged
+
+# Run HMDA isolation check when API Python files are staged
+if git diff --cached --name-only | grep -q '^packages/api/.*\.py$'; then
+  echo "Running HMDA isolation check..."
+  bash scripts/lint-hmda-isolation.sh
+fi


### PR DESCRIPTION
## Summary
- Adds HMDA isolation lint check (`scripts/lint-hmda-isolation.sh`) to the Husky pre-commit hook
- Triggers only when `packages/api/**/*.py` files are staged, so non-API commits are unaffected
- Blocks commits that reference the `hmda` schema, `compliance_app` pool, or `HmdaDemographic` model outside `services/compliance/`

Covers story S-1-F25-05.

## Test plan
- [x] Stage a Python file in `packages/api/` and commit -- HMDA lint runs
- [x] Stage only non-API files and commit -- HMDA lint does not run
- [x] Introduce a temporary HMDA violation outside `services/compliance/` -- commit is blocked

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>