### PR TITLE
feat(api): CEO document access restriction (metadata only)

### DIFF
--- a/packages/api/src/main.py
+++ b/packages/api/src/main.py
@@ -11,7 +11,7 @@ from .admin import setup_admin
 from .core.config import settings
 from .inference.safety import log_safety_status
 from .observability import log_observability_status
-from .routes import admin, applications, chat, health, hmda, public
+from .routes import admin, applications, chat, documents, health, hmda, public
 
 
 @asynccontextmanager
@@ -43,6 +43,7 @@ app.include_router(health.router, prefix="/health", tags=["health"])
 app.include_router(public.router, prefix="/api/public", tags=["public"])
 app.include_router(applications.router, prefix="/api/applications", tags=["applications"])
 app.include_router(chat.router, prefix="/api", tags=["chat"])
+app.include_router(documents.router, prefix="/api", tags=["documents"])
 app.include_router(hmda.router, prefix="/api/hmda", tags=["hmda"])
 app.include_router(admin.router, prefix="/api/admin", tags=["admin"])
 

--- a/packages/api/src/middleware/auth.py
+++ b/packages/api/src/middleware/auth.py
@@ -32,10 +32,7 @@ _jwks_fetched_at: float = 0
 
 def _fetch_jwks() -> dict:
     """Fetch JSON Web Key Set from Keycloak. Raises on failure."""
-    url = (
-        f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}"
-        "/protocol/openid-connect/certs"
-    )
+    url = f"{settings.KEYCLOAK_URL}/realms/{settings.KEYCLOAK_REALM}/protocol/openid-connect/certs"
     response = httpx.get(url, timeout=5)
     response.raise_for_status()
     return response.json()
@@ -85,6 +82,7 @@ def _get_signing_key(token: str) -> jwt.PyJWK:
 # ---------------------------------------------------------------------------
 # Token validation
 # ---------------------------------------------------------------------------
+
 
 def _extract_token(request: Request) -> str | None:
     """Extract Bearer token from Authorization header."""
@@ -141,7 +139,7 @@ def _build_data_scope(role: UserRole, user_id: str) -> DataScope:
     if role == UserRole.LOAN_OFFICER:
         return DataScope(assigned_to=user_id)
     if role == UserRole.CEO:
-        return DataScope(pii_mask=True, full_pipeline=True)
+        return DataScope(pii_mask=True, document_metadata_only=True, full_pipeline=True)
     if role == UserRole.UNDERWRITER:
         return DataScope(full_pipeline=True)
     if role == UserRole.ADMIN:

--- a/packages/api/src/routes/documents.py
+++ b/packages/api/src/routes/documents.py
@@ -1,0 +1,105 @@
+# This project was developed with assistance from AI tools.
+"""Document routes with CEO content restriction (Layer 1)."""
+
+from db import get_db
+from db.enums import UserRole
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..middleware.auth import CurrentUser, require_roles
+from ..schemas.document import (
+    DocumentDetailResponse,
+    DocumentListResponse,
+    DocumentResponse,
+)
+from ..services import document as doc_service
+from ..services.document import DocumentAccessDenied
+
+router = APIRouter()
+
+_ALL_AUTHENTICATED = (
+    UserRole.ADMIN,
+    UserRole.BORROWER,
+    UserRole.LOAN_OFFICER,
+    UserRole.UNDERWRITER,
+    UserRole.CEO,
+)
+
+_CONTENT_ROLES = (
+    UserRole.ADMIN,
+    UserRole.BORROWER,
+    UserRole.LOAN_OFFICER,
+    UserRole.UNDERWRITER,
+)
+
+
+@router.get(
+    "/applications/{application_id}/documents",
+    response_model=DocumentListResponse,
+    dependencies=[Depends(require_roles(*_ALL_AUTHENTICATED))],
+)
+async def list_documents(
+    application_id: int,
+    user: CurrentUser,
+    session: AsyncSession = Depends(get_db),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=20, ge=1, le=100),
+):
+    """List documents for an application. All roles see metadata only."""
+    documents, total = await doc_service.list_documents(
+        session,
+        user,
+        application_id,
+        offset=offset,
+        limit=limit,
+    )
+    items = [DocumentResponse.model_validate(doc) for doc in documents]
+    return DocumentListResponse(data=items, count=total)
+
+
+@router.get(
+    "/documents/{document_id}",
+    response_model=DocumentResponse | DocumentDetailResponse,
+    dependencies=[Depends(require_roles(*_ALL_AUTHENTICATED))],
+)
+async def get_document(
+    document_id: int,
+    user: CurrentUser,
+    session: AsyncSession = Depends(get_db),
+):
+    """Get document metadata. CEO sees metadata only; others see file_path too."""
+    doc = await doc_service.get_document(session, user, document_id)
+    if doc is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found",
+        )
+    if user.data_scope.document_metadata_only:
+        return DocumentResponse.model_validate(doc)
+    return DocumentDetailResponse.model_validate(doc)
+
+
+@router.get(
+    "/documents/{document_id}/content",
+    dependencies=[Depends(require_roles(*_CONTENT_ROLES))],
+)
+async def get_document_content(
+    document_id: int,
+    user: CurrentUser,
+    session: AsyncSession = Depends(get_db),
+):
+    """Get document content (file path). CEO is blocked at route level (Layer 1)."""
+    doc = await doc_service.get_document(session, user, document_id)
+    if doc is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Document not found",
+        )
+    try:
+        file_path = doc_service.get_document_content(user, doc)
+    except DocumentAccessDenied as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    return {"file_path": file_path}

--- a/packages/api/src/schemas/auth.py
+++ b/packages/api/src/schemas/auth.py
@@ -10,6 +10,7 @@ class DataScope(BaseModel):
 
     assigned_to: str | None = None
     pii_mask: bool = False
+    document_metadata_only: bool = False
     own_data_only: bool = False
     user_id: str | None = None
     full_pipeline: bool = False

--- a/packages/api/src/schemas/document.py
+++ b/packages/api/src/schemas/document.py
@@ -1,0 +1,35 @@
+# This project was developed with assistance from AI tools.
+"""Document request/response schemas."""
+
+from datetime import datetime
+
+from db.enums import DocumentStatus, DocumentType
+from pydantic import BaseModel, ConfigDict
+
+
+class DocumentResponse(BaseModel):
+    """Document metadata response (safe for all roles including CEO)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    application_id: int
+    doc_type: DocumentType
+    status: DocumentStatus
+    quality_flags: str | None = None
+    uploaded_by: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DocumentDetailResponse(DocumentResponse):
+    """Full document response including file_path (not for CEO)."""
+
+    file_path: str | None = None
+
+
+class DocumentListResponse(BaseModel):
+    """Paginated list of documents."""
+
+    data: list[DocumentResponse]
+    count: int

--- a/packages/api/src/services/document.py
+++ b/packages/api/src/services/document.py
@@ -1,0 +1,85 @@
+# This project was developed with assistance from AI tools.
+"""Document service with content restriction for metadata-only scopes.
+
+Roles with document_metadata_only scope see document metadata only --
+file_path and content are stripped at the service layer (defense-in-depth
+Layer 2). The route layer provides Layer 1, and the response schema
+provides Layer 4.
+"""
+
+import logging
+
+from db import Application, Borrower, Document
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..schemas.auth import DataScope, UserContext
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentAccessDenied(Exception):
+    """Raised when a role is not allowed to access document content."""
+
+
+def _apply_scope(stmt, scope: DataScope, user: UserContext):
+    """Apply data scope filtering to a document query via its application."""
+    if scope.own_data_only and scope.user_id:
+        stmt = (
+            stmt.join(Document.application)
+            .join(Application.borrower)
+            .where(Borrower.keycloak_user_id == scope.user_id)
+        )
+    elif scope.assigned_to:
+        stmt = stmt.join(Document.application).where(Application.assigned_to == scope.assigned_to)
+    return stmt
+
+
+async def list_documents(
+    session: AsyncSession,
+    user: UserContext,
+    application_id: int,
+    *,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[Document], int]:
+    """Return documents for an application visible to the current user."""
+    count_stmt = select(func.count(Document.id)).where(Document.application_id == application_id)
+    count_stmt = _apply_scope(count_stmt, user.data_scope, user)
+    total = (await session.execute(count_stmt)).scalar() or 0
+
+    stmt = (
+        select(Document)
+        .where(Document.application_id == application_id)
+        .order_by(Document.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+    )
+    stmt = _apply_scope(stmt, user.data_scope, user)
+    result = await session.execute(stmt)
+    documents = result.unique().scalars().all()
+
+    return documents, total
+
+
+async def get_document(
+    session: AsyncSession,
+    user: UserContext,
+    document_id: int,
+) -> Document | None:
+    """Return a single document if visible to the current user."""
+    stmt = select(Document).where(Document.id == document_id)
+    stmt = _apply_scope(stmt, user.data_scope, user)
+    result = await session.execute(stmt)
+    return result.unique().scalar_one_or_none()
+
+
+def get_document_content(user: UserContext, document: Document) -> str | None:
+    """Return document file_path, enforcing content restriction.
+
+    Raises DocumentAccessDenied for metadata-only scopes (service-level
+    enforcement, defense-in-depth Layer 2).
+    """
+    if user.data_scope.document_metadata_only:
+        raise DocumentAccessDenied("Document content access denied (metadata-only scope)")
+    return document.file_path

--- a/packages/api/tests/test_documents.py
+++ b/packages/api/tests/test_documents.py
@@ -1,0 +1,220 @@
+# This project was developed with assistance from AI tools.
+"""Tests for document endpoints and CEO content restriction."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from db import get_db
+from db.enums import DocumentStatus, DocumentType, UserRole
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.middleware.auth import get_current_user
+from src.routes.documents import router
+from src.schemas.auth import DataScope, UserContext
+from src.services.document import DocumentAccessDenied, get_document_content
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(role: UserRole, **kwargs) -> UserContext:
+    """Build a UserContext for the given role."""
+    defaults = {
+        "user_id": "test-user",
+        "email": "test@summit-cap.com",
+        "name": "Test User",
+        "data_scope": DataScope(full_pipeline=True),
+    }
+    if role == UserRole.CEO:
+        defaults["data_scope"] = DataScope(
+            pii_mask=True,
+            document_metadata_only=True,
+            full_pipeline=True,
+        )
+    if role == UserRole.BORROWER:
+        defaults["data_scope"] = DataScope(own_data_only=True, user_id="test-user")
+    defaults.update(kwargs)
+    return UserContext(role=role, **defaults)
+
+
+def _make_document(**overrides):
+    """Build a mock Document ORM object."""
+    doc = MagicMock()
+    doc.id = overrides.get("id", 1)
+    doc.application_id = overrides.get("application_id", 100)
+    doc.doc_type = overrides.get("doc_type", DocumentType.W2)
+    doc.status = overrides.get("status", DocumentStatus.UPLOADED)
+    doc.quality_flags = overrides.get("quality_flags", None)
+    doc.uploaded_by = overrides.get("uploaded_by", "james.torres")
+    doc.file_path = overrides.get("file_path", "/uploads/w2-2024.pdf")
+    doc.created_at = overrides.get("created_at", "2026-01-15T10:00:00+00:00")
+    doc.updated_at = overrides.get("updated_at", "2026-01-15T10:00:00+00:00")
+    return doc
+
+
+def _make_app(user: UserContext, documents: list | None = None):
+    """Build a test FastAPI app with document routes and mocked deps."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+
+    async def fake_user():
+        return user
+
+    mock_session = AsyncMock()
+
+    if documents is not None:
+        mock_result = MagicMock()
+        if len(documents) == 0:
+            mock_result.scalar.return_value = 0
+            mock_result.unique.return_value.scalar_one_or_none.return_value = None
+            mock_result.unique.return_value.scalars.return_value.all.return_value = []
+        elif len(documents) == 1:
+            mock_result.scalar.return_value = 1
+            mock_result.unique.return_value.scalar_one_or_none.return_value = documents[0]
+            mock_result.unique.return_value.scalars.return_value.all.return_value = documents
+        else:
+            mock_result.scalar.return_value = len(documents)
+            mock_result.unique.return_value.scalar_one_or_none.return_value = documents[0]
+            mock_result.unique.return_value.scalars.return_value.all.return_value = documents
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def fake_db():
+        yield mock_session
+
+    app.dependency_overrides[get_current_user] = fake_user
+    app.dependency_overrides[get_db] = fake_db
+    return app
+
+
+# ---------------------------------------------------------------------------
+# CEO restriction tests
+# ---------------------------------------------------------------------------
+
+
+def test_ceo_get_document_excludes_file_path():
+    """CEO gets metadata only -- no file_path in response."""
+    ceo = _make_user(UserRole.CEO)
+    doc = _make_document(file_path="/uploads/secret.pdf")
+    app = _make_app(ceo, documents=[doc])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert "file_path" not in data
+    assert data["doc_type"] == DocumentType.W2.value
+    assert data["status"] == DocumentStatus.UPLOADED.value
+
+
+def test_ceo_content_endpoint_returns_403():
+    """CEO is blocked from /documents/{id}/content at route level."""
+    from src.core.config import settings
+
+    settings.AUTH_DISABLED = False
+
+    ceo = _make_user(UserRole.CEO)
+    doc = _make_document()
+    app = _make_app(ceo, documents=[doc])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/1/content")
+    assert response.status_code == 403
+
+    settings.AUTH_DISABLED = True
+
+
+def test_ceo_service_layer_blocks_content():
+    """Service-level enforcement: get_document_content raises for CEO."""
+    ceo = _make_user(UserRole.CEO)
+    doc = _make_document(file_path="/uploads/w2.pdf")
+
+    try:
+        get_document_content(ceo, doc)
+        assert False, "Should have raised DocumentAccessDenied"
+    except DocumentAccessDenied:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Non-CEO access tests
+# ---------------------------------------------------------------------------
+
+
+def test_loan_officer_gets_full_document():
+    """Loan officer gets document with file_path included."""
+    lo = _make_user(UserRole.LOAN_OFFICER, data_scope=DataScope(assigned_to="test-user"))
+    doc = _make_document(file_path="/uploads/paystub.pdf")
+    app = _make_app(lo, documents=[doc])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["file_path"] == "/uploads/paystub.pdf"
+
+
+def test_loan_officer_content_endpoint_succeeds():
+    """Loan officer can access /documents/{id}/content."""
+    lo = _make_user(UserRole.LOAN_OFFICER, data_scope=DataScope(assigned_to="test-user"))
+    doc = _make_document(file_path="/uploads/paystub.pdf")
+    app = _make_app(lo, documents=[doc])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/1/content")
+    assert response.status_code == 200
+    assert response.json()["file_path"] == "/uploads/paystub.pdf"
+
+
+def test_service_layer_allows_non_ceo_content():
+    """Service-level enforcement allows non-CEO roles."""
+    lo = _make_user(UserRole.LOAN_OFFICER)
+    doc = _make_document(file_path="/uploads/w2.pdf")
+    result = get_document_content(lo, doc)
+    assert result == "/uploads/w2.pdf"
+
+
+# ---------------------------------------------------------------------------
+# List endpoint tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_documents_returns_metadata_only():
+    """List endpoint returns metadata schema (no file_path) for all roles."""
+    admin = _make_user(UserRole.ADMIN)
+    docs = [_make_document(id=i) for i in range(3)]
+    app = _make_app(admin, documents=docs)
+    client = TestClient(app)
+
+    response = client.get("/api/applications/100/documents")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 3
+    assert len(data["data"]) == 3
+    for item in data["data"]:
+        assert "file_path" not in item
+
+
+# ---------------------------------------------------------------------------
+# 404 tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_nonexistent_document_returns_404():
+    """Requesting a missing document returns 404."""
+    admin = _make_user(UserRole.ADMIN)
+    app = _make_app(admin, documents=[])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/999")
+    assert response.status_code == 404
+
+
+def test_content_nonexistent_document_returns_404():
+    """Requesting content of a missing document returns 404."""
+    admin = _make_user(UserRole.ADMIN)
+    app = _make_app(admin, documents=[])
+    client = TestClient(app)
+
+    response = client.get("/api/documents/999/content")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Adds document endpoints: `GET /api/applications/{id}/documents`, `GET /api/documents/{id}`, `GET /api/documents/{id}/content`
- CEO role sees document metadata only (type, status, quality flags, dates) -- `file_path` is excluded from the response schema
- CEO is blocked from `/documents/{id}/content` with 403 at both route level (role gate) and service level (`DocumentAccessDenied` exception)
- Defense-in-depth enforcement at 3 layers: route (Layer 1), service (Layer 2), schema (Layer 4)
- All other authenticated roles get full document detail including `file_path`

Covers story S-1-F14-04.

## Test plan
- [x] CEO `GET /documents/{id}` returns metadata without `file_path`
- [x] CEO `GET /documents/{id}/content` returns 403
- [x] Service layer `get_document_content()` raises for CEO role
- [x] Loan officer gets full document detail with `file_path`
- [x] Loan officer can access `/content` endpoint
- [x] List endpoint returns metadata-only schema for all roles
- [x] 404 for nonexistent documents on both endpoints
- [x] 91/91 tests pass, ruff clean, HMDA isolation lint passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>