### PR TITLE
feat(api): add trace-to-audit event correlation via session_id

### DIFF
--- a/packages/api/src/routes/chat.py
+++ b/packages/api/src/routes/chat.py
@@ -7,17 +7,22 @@ Protocol:
                  {"type": "safety_override", "content": "..."} (output shield replaced response)
                  {"type": "done"} (end of response)
                  {"type": "error", "content": "..."} (on failure)
+
+Audit events are written with the same session_id used for LangFuse traces,
+enabling trace-to-audit correlation (S-1-F18-03).
 """
 
 import json
 import logging
 import uuid
 
+from db import get_db
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 
 from ..agents.registry import get_agent
 from ..observability import build_langfuse_config, flush_langfuse
+from ..services.audit import write_audit_event
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +48,24 @@ async def chat_websocket(ws: WebSocket):
     messages: list = []
     session_id = str(uuid.uuid4())
     langfuse_config = build_langfuse_config(session_id=session_id)
+    user_role = "prospect"
+    user_id = session_id
+
+    async def _audit(event_type: str, event_data: dict | None = None) -> None:
+        """Write an audit event with the shared session_id."""
+        try:
+            async for db_session in get_db():
+                await write_audit_event(
+                    db_session,
+                    event_type=event_type,
+                    session_id=session_id,
+                    user_id=user_id,
+                    user_role=user_role,
+                    event_data=event_data,
+                )
+                await db_session.commit()
+        except Exception:
+            logger.debug("Failed to write audit event %s", event_type, exc_info=True)
 
     try:
         while True:
@@ -67,8 +90,8 @@ async def chat_websocket(ws: WebSocket):
                 async for event in graph.astream_events(
                     {
                         "messages": messages,
-                        "user_role": "prospect",
-                        "user_id": session_id,
+                        "user_role": user_role,
+                        "user_id": user_id,
                     },
                     config=langfuse_config,
                     version="v2",
@@ -89,15 +112,33 @@ async def chat_websocket(ws: WebSocket):
                                 if hasattr(msg, "content") and msg.content:
                                     await ws.send_json({"type": "token", "content": msg.content})
                                     full_response = msg.content
+                            await _audit("safety_block", {"shield": "input", "blocked": True})
 
                     elif kind == "on_chain_end" and node == "tool_auth":
                         output = event.get("data", {}).get("output")
                         if isinstance(output, dict):
                             auth_msgs = output.get("messages", [])
                             if auth_msgs:
-                                # tool_auth denied -- the agent will rephrase,
-                                # but stream the denial for transparency
                                 logger.info("Tool auth denied for session %s", session_id)
+                                await _audit(
+                                    "tool_auth_denied",
+                                    {
+                                        "message": auth_msgs[-1].content
+                                        if hasattr(auth_msgs[-1], "content")
+                                        else str(auth_msgs[-1]),
+                                    },
+                                )
+
+                    elif kind == "on_tool_end":
+                        tool_output = event.get("data", {}).get("output")
+                        tool_name = event.get("name", "unknown")
+                        await _audit(
+                            "tool_invocation",
+                            {
+                                "tool_name": tool_name,
+                                "result_length": len(str(tool_output)) if tool_output else 0,
+                            },
+                        )
 
                     elif kind == "on_chain_end" and node == "output_shield":
                         output = event.get("data", {}).get("output")
@@ -107,6 +148,13 @@ async def chat_websocket(ws: WebSocket):
                                 override = shield_msgs[-1].content
                                 await ws.send_json({"type": "safety_override", "content": override})
                                 full_response = override
+                                await _audit(
+                                    "safety_block",
+                                    {
+                                        "shield": "output",
+                                        "blocked": True,
+                                    },
+                                )
 
                 # Add assistant response to history
                 if full_response:

--- a/packages/api/src/services/audit.py
+++ b/packages/api/src/services/audit.py
@@ -1,0 +1,72 @@
+# This project was developed with assistance from AI tools.
+"""Audit event service.
+
+Writes append-only audit trail entries with session_id for LangFuse trace
+correlation (S-1-F18-03). The same session_id used in LangFuse metadata
+is written here, enabling cross-lookup between developer-facing traces
+and compliance-facing audit logs.
+"""
+
+import json
+import logging
+
+from db import AuditEvent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def write_audit_event(
+    session: AsyncSession,
+    *,
+    event_type: str,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    user_role: str | None = None,
+    application_id: int | None = None,
+    event_data: dict | None = None,
+) -> AuditEvent:
+    """Write a single audit event.
+
+    Args:
+        session: Database session.
+        event_type: Event category (e.g. 'tool_invocation', 'safety_block').
+        session_id: WebSocket/LangFuse session ID for trace correlation.
+        user_id: User who triggered the event.
+        user_role: Role at the time of the event.
+        application_id: Related application, if any.
+        event_data: Arbitrary JSON-serializable event payload.
+
+    Returns:
+        The created AuditEvent row.
+    """
+    audit = AuditEvent(
+        event_type=event_type,
+        session_id=session_id,
+        user_id=user_id,
+        user_role=user_role,
+        application_id=application_id,
+        event_data=json.dumps(event_data) if event_data else None,
+    )
+    session.add(audit)
+    await session.flush()
+    return audit
+
+
+async def get_events_by_session(
+    session: AsyncSession,
+    session_id: str,
+) -> list[AuditEvent]:
+    """Return all audit events for a given session_id.
+
+    This is the compliance-side query for trace-audit correlation:
+    given a session_id from LangFuse, retrieve all audit events.
+    """
+    stmt = (
+        select(AuditEvent)
+        .where(AuditEvent.session_id == session_id)
+        .order_by(AuditEvent.timestamp.asc())
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())


### PR DESCRIPTION
## Summary
- Add `src/services/audit.py` -- thin service for writing audit events with `session_id` matching LangFuse traces
- Chat WebSocket now writes audit events for: tool invocations, input/output safety blocks, and tool auth denials
- Add `GET /api/admin/audit?session_id=` endpoint for cross-lookup between developer-facing LangFuse traces and compliance-facing audit logs
- Same UUID `session_id` flows into both `langfuse_session_id` metadata and `AuditEvent.session_id` column

## Test plan
- [x] `test_write_audit_event_creates_row` -- service writes event with all fields including session_id
- [x] `test_write_audit_event_without_event_data` -- event_data is optional
- [x] `test_get_events_by_session_queries_by_session_id` -- query filters by session_id
- [x] `test_audit_endpoint_returns_events_for_session` -- GET returns matching events
- [x] `test_audit_endpoint_returns_empty_for_unknown_session` -- empty list for unknown session
- [x] `test_audit_endpoint_requires_session_id` -- 422 without session_id param
- [x] `test_audit_endpoint_requires_admin_role` -- 403 for non-admin
- [x] `test_session_id_matches_langfuse_and_audit` -- correlation contract verified
- [x] All 107 existing tests pass
- [x] Ruff clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>