### PR TITLE
chore: add make smoke target for pre-demo container validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ help:
 	@echo "    containers-logs  View logs for all containers"
 	@echo "    build-images     Build API and UI container images"
 	@echo "    push-images      Push images to registry (default: quay.io)"
+	@echo "    smoke            Smoke test: start stack, check endpoints, tear down"
 	@echo ""
 	@echo "  Deployment (OpenShift):"
 	@echo "    deploy           Deploy application using Helm"
@@ -179,6 +180,9 @@ build-images:
 push-images:
 	@scripts/push-images.sh
 
+smoke:
+	@COMPOSE="$(COMPOSE)" scripts/smoke-test.sh
+
 # -- Deployment (OpenShift) --------------------------------------------------
 
 create-project:
@@ -267,6 +271,6 @@ helm-template: helm-dep-update
         setup dev build test lint lint-hmda clean \
         db-start db-stop db-logs db-upgrade \
         containers-build containers-up containers-down containers-logs \
-        build-images push-images \
+        build-images push-images smoke \
         create-project helm-dep-update deploy deploy-dev undeploy status debug \
         helm-lint helm-template

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# This project was developed with assistance from AI tools.
+#
+# Smoke test: start the minimal compose stack, wait for health checks,
+# hit a few endpoints, then tear down. Run before demos to catch
+# container misconfigs.
+#
+# Usage:
+#   make smoke
+#   scripts/smoke-test.sh                   # uses auto-detected compose
+#   COMPOSE="podman-compose" scripts/smoke-test.sh
+
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-$(docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "podman-compose")}"
+API_URL="http://localhost:8000"
+UI_URL="http://localhost:3000"
+TIMEOUT=120
+PASSED=0
+FAILED=0
+
+# -- Helpers -----------------------------------------------------------------
+
+log()  { printf "\033[1;34m[smoke]\033[0m %s\n" "$*"; }
+pass() { printf "\033[1;32m  PASS\033[0m %s\n" "$*"; PASSED=$((PASSED + 1)); }
+fail() { printf "\033[1;31m  FAIL\033[0m %s\n" "$*"; FAILED=$((FAILED + 1)); }
+
+cleanup() {
+    log "Tearing down containers..."
+    $COMPOSE down --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_healthy() {
+    local service="$1"
+    local elapsed=0
+
+    log "Waiting for $service to become healthy (timeout: ${TIMEOUT}s)..."
+    while [ $elapsed -lt $TIMEOUT ]; do
+        local health
+        health=$($COMPOSE ps --format json 2>/dev/null \
+            | python3 -c "
+import json, sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    svc = json.loads(line)
+    if svc.get('Service') == '$service' or svc.get('Name','').startswith('$service'):
+        print(svc.get('Health','unknown'))
+        break
+" 2>/dev/null || echo "unknown")
+
+        if [ "$health" = "healthy" ]; then
+            return 0
+        fi
+        sleep 3
+        elapsed=$((elapsed + 3))
+    done
+    return 1
+}
+
+check_endpoint() {
+    local label="$1"
+    local url="$2"
+    local expect_status="${3:-200}"
+
+    local status
+    status=$(curl -sf -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")
+    if [ "$status" = "$expect_status" ]; then
+        pass "$label -> $status"
+    else
+        fail "$label -> $status (expected $expect_status)"
+    fi
+}
+
+check_json_field() {
+    local label="$1"
+    local url="$2"
+    local jq_expr="$3"
+
+    local result
+    result=$(curl -sf "$url" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+# simple dotted path eval
+val = data
+for key in '$jq_expr'.split('.'):
+    if key == '':
+        continue
+    if isinstance(val, list):
+        val = val[int(key)]
+    else:
+        val = val[key]
+print(val)
+" 2>/dev/null || echo "ERROR")
+
+    if [ "$result" != "ERROR" ] && [ -n "$result" ]; then
+        pass "$label -> $result"
+    else
+        fail "$label (could not extract $jq_expr)"
+    fi
+}
+
+# -- Main --------------------------------------------------------------------
+
+log "Starting minimal compose stack..."
+$COMPOSE up -d
+
+if wait_for_healthy "summit-cap-db"; then
+    pass "summit-cap-db healthy"
+else
+    fail "summit-cap-db did not become healthy within ${TIMEOUT}s"
+fi
+
+if wait_for_healthy "summit-cap-api"; then
+    pass "summit-cap-api healthy"
+else
+    fail "summit-cap-api did not become healthy within ${TIMEOUT}s"
+fi
+
+if wait_for_healthy "summit-cap-ui"; then
+    pass "summit-cap-ui healthy"
+else
+    fail "summit-cap-ui did not become healthy within ${TIMEOUT}s"
+fi
+
+log "Running endpoint checks..."
+
+# API health
+check_endpoint "GET /health/" "$API_URL/health/"
+check_json_field "API health status" "$API_URL/health/" "0.status"
+
+# API root
+check_endpoint "GET /" "$API_URL/"
+
+# Public endpoints (no auth)
+check_endpoint "GET /api/public/products" "$API_URL/api/public/products"
+check_endpoint "POST /api/public/calculate-affordability" \
+    "$API_URL/api/public/calculate-affordability" "422"
+    # 422 expected: no body sent, validation error confirms the route is live
+
+# Applications (AUTH_DISABLED=true in compose, so dev-user admin)
+check_endpoint "GET /api/applications/" "$API_URL/api/applications/"
+
+# UI serves HTML
+check_endpoint "GET UI root" "$UI_URL/"
+
+# -- Summary -----------------------------------------------------------------
+
+echo ""
+log "Results: $PASSED passed, $FAILED failed"
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/smoke-test.sh` that starts the minimal compose stack, waits for health checks, validates key endpoints, and tears down
- Add `make smoke` Makefile target wired to the script
- Auto-detects `docker compose` vs `podman-compose`, uses `trap` for guaranteed cleanup

Checks performed:
- DB, API, UI containers reach `healthy` state (120s timeout)
- `GET /health/` returns 200 with valid status JSON
- `GET /` (API root) returns 200
- `GET /api/public/products` returns 200
- `POST /api/public/calculate-affordability` returns 422 (route live, validation catches empty body)
- `GET /api/applications/` returns 200 (AUTH_DISABLED=true in compose)
- `GET /` (UI root) returns 200

## Test plan

- [ ] `make smoke` starts stack, runs checks, tears down cleanly
- [ ] Script exits 1 if any check fails, 0 if all pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>