### PR TITLE
feat(api): add document extraction pipeline with HMDA demographic filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 lib/
 out/
 
+agent-memory/
+
 # Environment variables
 .env
 .env.local

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "langgraph-checkpoint-postgres>=2.0.0",
     "psycopg[binary]>=3.1.0",
     "boto3>=1.34.0",
+    "pymupdf>=1.24.0",
 
     "summit-cap-db",
 ]

--- a/packages/api/src/main.py
+++ b/packages/api/src/main.py
@@ -19,11 +19,13 @@ async def lifespan(_app: FastAPI):
     log_safety_status()
     log_observability_status()
     from .services.conversation import get_conversation_service
+    from .services.extraction import init_extraction_service
     from .services.storage import init_storage_service
 
     conversation_service = get_conversation_service()
     await conversation_service.initialize(settings.DATABASE_URL)
     init_storage_service(settings)
+    init_extraction_service()
     yield
     await conversation_service.shutdown()
 

--- a/packages/api/src/services/extraction.py
+++ b/packages/api/src/services/extraction.py
@@ -1,0 +1,288 @@
+# This project was developed with assistance from AI tools.
+"""Document extraction pipeline.
+
+Two-stage extraction: text extraction (pymupdf) then structured extraction
+(LLM). Scanned PDFs and images fall back to LLM vision. Post-extraction
+HMDA filter routes demographic fields to the compliance schema via
+``services.compliance.hmda`` (the sole permitted HMDA accessor).
+"""
+
+import base64
+import json
+import logging
+import re
+
+import fitz  # pymupdf
+from db import (
+    Document,
+    DocumentExtraction,
+)
+from db.database import SessionLocal
+from db.enums import DocumentStatus
+from sqlalchemy import select
+
+from ..inference.client import get_completion
+from .compliance.hmda import route_extraction_demographics
+from .extraction_prompts import (
+    HMDA_KEYWORDS,
+    build_extraction_prompt,
+    build_image_extraction_prompt,
+)
+from .storage import get_storage_service
+
+logger = logging.getLogger(__name__)
+
+# Minimum text length to consider PDF text extraction successful.
+# Below this threshold we assume the PDF is scanned (image-only).
+_MIN_TEXT_LENGTH = 50
+
+# Matches ```json ... ``` or ``` ... ``` fences that LLMs often wrap around JSON.
+_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?(.*?)\n?\s*```$", re.DOTALL)
+
+
+def _strip_json_fences(text: str) -> str:
+    """Remove markdown code fences wrapping JSON output.
+
+    Many LLMs wrap JSON in ```json ... ``` blocks when not constrained by
+    response_format. This strips the fences so json.loads() succeeds.
+    """
+    stripped = text.strip()
+    m = _FENCE_RE.match(stripped)
+    return m.group(1).strip() if m else stripped
+
+
+class ExtractionService:
+    """Orchestrates download -> extract -> persist for uploaded documents."""
+
+    async def process_document(self, document_id: int) -> None:
+        """Main pipeline entry point. Runs as a background task with own DB sessions."""
+        async with SessionLocal() as session:
+            try:
+                stmt = select(Document).where(Document.id == document_id)
+                result = await session.execute(stmt)
+                doc = result.scalar_one_or_none()
+                if doc is None:
+                    logger.error("Document %s not found, skipping extraction", document_id)
+                    return
+
+                file_path = doc.file_path
+                doc_type = doc.doc_type.value
+                application_id = doc.application_id
+                content_type = self._guess_content_type(file_path)
+
+                # Download from S3
+                storage = get_storage_service()
+                file_data = await storage.download_file(file_path)
+
+                # Run extraction based on content type
+                if content_type == "application/pdf":
+                    llm_result = await self._process_pdf(file_data, doc_type)
+                else:
+                    # JPEG/PNG -> direct to LLM vision
+                    llm_result = await self._extract_image_via_llm(
+                        file_data, content_type, doc_type
+                    )
+
+                if llm_result is None:
+                    # Extraction failed (corrupted, unreadable)
+                    doc.status = DocumentStatus.PROCESSING_FAILED
+                    doc.quality_flags = json.dumps(["unreadable"])
+                    await session.commit()
+                    return
+
+                extractions = llm_result.get("extractions", [])
+                quality_flags = llm_result.get("quality_flags", [])
+                detected_doc_type = llm_result.get("detected_doc_type", doc_type)
+
+                # Check for empty extractions (LLM couldn't read)
+                if not extractions:
+                    doc.status = DocumentStatus.PROCESSING_FAILED
+                    doc.quality_flags = json.dumps(["unreadable"])
+                    await session.commit()
+                    return
+
+                # Document type mismatch detection
+                if detected_doc_type and detected_doc_type != doc_type:
+                    quality_flags.append("document_type_mismatch")
+
+                # HMDA demographic filter
+                lending_extractions, demographic_extractions = self._filter_hmda_fields(extractions)
+
+                # Route demographic data to compliance schema
+                if demographic_extractions:
+                    await route_extraction_demographics(
+                        document_id, application_id, demographic_extractions
+                    )
+
+                # Store quality flags
+                doc.quality_flags = json.dumps(quality_flags) if quality_flags else None
+
+                # Persist lending-path extractions
+                for ext in lending_extractions:
+                    extraction = DocumentExtraction(
+                        document_id=document_id,
+                        field_name=ext.get("field_name", ""),
+                        field_value=ext.get("field_value"),
+                        confidence=ext.get("confidence"),
+                        source_page=ext.get("source_page"),
+                    )
+                    session.add(extraction)
+
+                doc.status = DocumentStatus.PROCESSING_COMPLETE
+                await session.commit()
+                logger.info(
+                    "Document %s processed: %d extractions, %d flags",
+                    document_id,
+                    len(lending_extractions),
+                    len(quality_flags),
+                )
+
+            except Exception:
+                logger.exception("Extraction failed for document %s", document_id)
+                try:
+                    doc.status = DocumentStatus.PROCESSING_FAILED
+                    await session.commit()
+                except Exception:
+                    logger.exception("Failed to update status for document %s", document_id)
+
+    async def _process_pdf(self, file_data: bytes, doc_type: str) -> dict | None:
+        """Process a PDF: try text extraction, fall back to image if scanned."""
+        text = self._extract_text_from_pdf(file_data)
+        if text is None:
+            # Corrupted / unopenable PDF
+            return None
+
+        if len(text) >= _MIN_TEXT_LENGTH:
+            # Sufficient text layer -- use text-based extraction
+            return await self._extract_via_llm(text, doc_type)
+
+        # Scanned PDF -- render pages to images and use vision
+        images = self._pdf_pages_to_images(file_data)
+        if not images:
+            return None
+
+        return await self._extract_image_via_llm(images[0], "image/png", doc_type)
+
+    def _extract_text_from_pdf(self, file_data: bytes) -> str | None:
+        """Use pymupdf to extract text from all pages.
+
+        Returns None if PDF is corrupted/unopenable.
+        Returns empty string if no text layer (scanned doc).
+        """
+        try:
+            pdf = fitz.open(stream=file_data, filetype="pdf")
+            text_parts = []
+            for page in pdf:
+                text_parts.append(page.get_text())
+            pdf.close()
+            return " ".join(text_parts).strip()
+        except Exception:
+            logger.exception("Failed to open PDF with pymupdf")
+            return None
+
+    def _pdf_pages_to_images(self, file_data: bytes) -> list[bytes]:
+        """Render PDF pages as PNG images via pymupdf get_pixmap()."""
+        try:
+            pdf = fitz.open(stream=file_data, filetype="pdf")
+            images = []
+            for page in pdf:
+                pix = page.get_pixmap()
+                images.append(pix.tobytes("png"))
+            pdf.close()
+            return images
+        except Exception:
+            logger.exception("Failed to render PDF pages to images")
+            return []
+
+    async def _extract_via_llm(self, text: str, doc_type: str) -> dict | None:
+        """Send text to LLM, get structured extractions + quality flags."""
+        messages = build_extraction_prompt(doc_type, text)
+        try:
+            raw = await get_completion(messages, tier="capable_large")
+            return json.loads(_strip_json_fences(raw))
+        except json.JSONDecodeError:
+            logger.error("LLM returned non-JSON for text extraction")
+            return None
+
+    async def _extract_image_via_llm(
+        self,
+        image_data: bytes,
+        content_type: str,
+        doc_type: str,
+    ) -> dict | None:
+        """Send image to LLM vision, get structured extractions + quality flags."""
+        system_msg = build_image_extraction_prompt(doc_type)
+        b64 = base64.b64encode(image_data).decode("ascii")
+        messages = [
+            system_msg,
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{content_type};base64,{b64}"},
+                    },
+                    {"type": "text", "text": "Extract data from this document image."},
+                ],
+            },
+        ]
+        try:
+            raw = await get_completion(messages, tier="capable_large")
+            return json.loads(_strip_json_fences(raw))
+        except json.JSONDecodeError:
+            logger.error("LLM returned non-JSON for image extraction")
+            return None
+
+    def _filter_hmda_fields(
+        self,
+        extractions: list[dict],
+    ) -> tuple[list[dict], list[dict]]:
+        """Separate demographic from lending-path extractions.
+
+        Returns (lending_extractions, demographic_extractions).
+        """
+        lending = []
+        demographic = []
+        for ext in extractions:
+            field_name = ext.get("field_name", "").lower().replace(" ", "_").replace("-", "_")
+            if field_name in HMDA_KEYWORDS:
+                demographic.append(ext)
+            else:
+                lending.append(ext)
+        return lending, demographic
+
+    @staticmethod
+    def _guess_content_type(file_path: str) -> str:
+        """Guess content type from file extension in the S3 key."""
+        lower = file_path.lower()
+        if lower.endswith(".pdf"):
+            return "application/pdf"
+        if lower.endswith((".jpg", ".jpeg")):
+            return "image/jpeg"
+        if lower.endswith(".png"):
+            return "image/png"
+        return "application/pdf"  # default to PDF
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_service: ExtractionService | None = None
+
+
+def init_extraction_service() -> ExtractionService:
+    """Initialise the singleton (called once from app lifespan)."""
+    global _service  # noqa: PLW0603
+    _service = ExtractionService()
+    logger.info("ExtractionService initialised")
+    return _service
+
+
+def get_extraction_service() -> ExtractionService:
+    """Return the initialised ExtractionService singleton."""
+    if _service is None:
+        raise RuntimeError(
+            "ExtractionService not initialised -- call init_extraction_service() first"
+        )
+    return _service

--- a/packages/api/src/services/extraction_prompts.py
+++ b/packages/api/src/services/extraction_prompts.py
@@ -1,0 +1,130 @@
+# This project was developed with assistance from AI tools.
+"""Document extraction prompt templates and field definitions.
+
+Keeps prompt construction separate from the extraction service so prompts
+can be reviewed and iterated on independently.
+"""
+
+EXTRACTION_FIELDS: dict[str, list[str]] = {
+    "w2": [
+        "employer_name",
+        "employee_name",
+        "tax_year",
+        "wages",
+        "federal_tax_withheld",
+        "state_tax_withheld",
+    ],
+    "pay_stub": [
+        "employer_name",
+        "pay_period_start",
+        "pay_period_end",
+        "gross_pay",
+        "net_pay",
+        "ytd_gross_pay",
+    ],
+    "bank_statement": [
+        "bank_name",
+        "account_number_last4",
+        "statement_period_start",
+        "statement_period_end",
+        "ending_balance",
+        "average_balance",
+    ],
+    "tax_return": [
+        "tax_year",
+        "filing_status",
+        "adjusted_gross_income",
+        "total_tax",
+        "taxable_income",
+    ],
+    "id": [
+        "full_name",
+        "date_of_birth",
+        "id_number_last4",
+        "expiration_date",
+        "issuing_authority",
+    ],
+}
+
+QUALITY_FLAGS = [
+    "blurry",
+    "incomplete",
+    "wrong_period",
+    "document_type_mismatch",
+    "unsigned",
+]
+
+# HMDA demographic keywords for post-extraction filter
+HMDA_KEYWORDS: set[str] = {
+    "race",
+    "ethnicity",
+    "sex",
+    "gender",
+    "marital_status",
+    "national_origin",
+    "disability",
+    "age_group",
+}
+
+
+def build_extraction_prompt(doc_type: str, text: str) -> list[dict]:
+    """Build messages for text-based LLM extraction."""
+    fields = EXTRACTION_FIELDS.get(doc_type, [])
+    fields_csv = ", ".join(fields) if fields else "any relevant fields"
+
+    system_msg = (
+        "You are a document extraction assistant for a mortgage lending system. "
+        "Extract structured data from the provided document text. "
+        "Respond ONLY with valid JSON matching this schema:\n"
+        "{\n"
+        '  "extractions": [\n'
+        '    {"field_name": "<name>", "field_value": "<value>", '
+        '"confidence": <0.0-1.0>, "source_page": <int>}\n'
+        "  ],\n"
+        f'  "quality_flags": [<zero or more of: {", ".join(QUALITY_FLAGS)}>],\n'
+        '  "detected_doc_type": "<actual document type detected>"\n'
+        "}\n\n"
+        f"Expected document type: {doc_type}\n"
+        f"Expected fields: {fields_csv}\n"
+        "IMPORTANT: If the document contains any demographic or government "
+        "monitoring information (race, ethnicity, sex, gender, marital status, "
+        "national origin), extract those fields as well.\n"
+        "If a field is not found, omit it. Do not guess values."
+    )
+
+    return [
+        {"role": "system", "content": system_msg},
+        {"role": "user", "content": f"Extract data from this document:\n\n{text}"},
+    ]
+
+
+def build_image_extraction_prompt(doc_type: str) -> dict:
+    """Build system message for image-based LLM extraction.
+
+    The image content block is added separately by the caller.
+    """
+    fields = EXTRACTION_FIELDS.get(doc_type, [])
+    fields_csv = ", ".join(fields) if fields else "any relevant fields"
+
+    return {
+        "role": "system",
+        "content": (
+            "You are a document extraction assistant for a mortgage lending system. "
+            "Extract structured data from the provided document image. "
+            "Respond ONLY with valid JSON matching this schema:\n"
+            "{\n"
+            '  "extractions": [\n'
+            '    {"field_name": "<name>", "field_value": "<value>", '
+            '"confidence": <0.0-1.0>, "source_page": <int>}\n'
+            "  ],\n"
+            f'  "quality_flags": [<zero or more of: {", ".join(QUALITY_FLAGS)}>],\n'
+            '  "detected_doc_type": "<actual document type detected>"\n'
+            "}\n\n"
+            f"Expected document type: {doc_type}\n"
+            f"Expected fields: {fields_csv}\n"
+            "IMPORTANT: If the document contains any demographic or government "
+            "monitoring information (race, ethnicity, sex, gender, marital status, "
+            "national origin), extract those fields as well.\n"
+            "If a field is not found, omit it. Do not guess values."
+        ),
+    }

--- a/packages/api/tests/functional/mock_db.py
+++ b/packages/api/tests/functional/mock_db.py
@@ -67,18 +67,13 @@ def make_upload_session(application: object | None = None) -> AsyncMock:
     mock_result.unique.return_value.scalar_one_or_none.return_value = application
     session.execute = AsyncMock(return_value=mock_result)
 
-    # Track the document added via session.add() so we can assign an id on flush
-    _added_doc = {}
-
-    original_add = session.add
-
+    # session.add() is synchronous in SQLAlchemy -- use MagicMock to avoid
+    # RuntimeWarning about unawaited coroutines from AsyncMock.
     def track_add(obj):
-        _added_doc["ref"] = obj
         obj.id = 501
         obj.created_at = "2026-02-24T12:00:00+00:00"
-        original_add(obj)
 
-    session.add = track_add
+    session.add = MagicMock(side_effect=track_add)
 
     return session
 

--- a/packages/api/tests/functional/test_extraction_flow.py
+++ b/packages/api/tests/functional/test_extraction_flow.py
@@ -1,0 +1,67 @@
+# This project was developed with assistance from AI tools.
+"""Functional tests: Document extraction pipeline flow.
+
+Tests through the real FastAPI app with mocked LLM, S3, and DB.
+Verifies:
+- Upload triggers background processing dispatch
+- Background task receives correct document ID
+"""
+
+from io import BytesIO
+
+import pytest
+
+from .data_factory import make_app_sarah_1
+from .mock_db import make_upload_session
+from .personas import borrower_sarah
+
+pytestmark = pytest.mark.functional
+
+
+def _post_upload(client, application_id=101, content_type="application/pdf", filename="test.pdf"):
+    """Helper: POST a file to the upload endpoint."""
+    data = b"%PDF-1.4 fake document content"
+    return client.post(
+        f"/api/applications/{application_id}/documents",
+        files={"file": (filename, BytesIO(data), content_type)},
+        data={"doc_type": "w2"},
+    )
+
+
+class TestUploadTriggersProcessing:
+    """Upload triggers background extraction dispatch."""
+
+    def test_upload_triggers_processing(self, make_upload_client):
+        """Upload returns 201 with status=processing and dispatches background task."""
+        app_obj = make_app_sarah_1()
+        session = make_upload_session(application=app_obj)
+        client, _mock_storage = make_upload_client(borrower_sarah(), session)
+
+        resp = _post_upload(client, application_id=101)
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["status"] == "processing"
+
+        # Verify extraction was dispatched via fixture's exposed mock
+        client._mock_create_task.assert_called_once()
+
+
+class TestExtractionDispatchesCorrectDocId:
+    """Background task receives the correct document ID."""
+
+    def test_extraction_dispatched_with_doc_id(self, make_upload_client):
+        """process_document is called with the newly created document's ID."""
+        app_obj = make_app_sarah_1()
+        session = make_upload_session(application=app_obj)
+        client, _mock_storage = make_upload_client(borrower_sarah(), session)
+
+        resp = _post_upload(client, application_id=101)
+
+        assert resp.status_code == 201
+
+        # The extraction service's process_document was called with the doc ID
+        client._mock_extraction_svc.process_document.assert_called_once_with(501)
+
+        # And that coroutine was passed to create_task
+        client._mock_create_task.assert_called_once()

--- a/packages/api/tests/test_extraction.py
+++ b/packages/api/tests/test_extraction.py
@@ -1,0 +1,610 @@
+# This project was developed with assistance from AI tools.
+"""Unit tests for the document extraction pipeline.
+
+All LLM calls and S3 downloads are mocked. Tests cover:
+- PDF text extraction (pymupdf)
+- Corrupted PDF handling
+- Scanned PDF fallback to image extraction
+- LLM text/image extraction
+- Malformed JSON handling
+- Empty extractions handling
+- Full pipeline happy paths (PDF + image)
+- Error handling (PROCESSING_FAILED)
+- HMDA demographic field filtering
+- HMDA routing to compliance schema
+- HMDA exclusion audit logging
+- Quality flags persistence
+- Document type mismatch detection
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from openai import BadRequestError
+
+from src.services.extraction import ExtractionService, _strip_json_fences
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_doc(
+    doc_id=1,
+    file_path="101/1/test.pdf",
+    doc_type_value="w2",
+    application_id=101,
+    status="processing",
+):
+    """Build a mock Document ORM object for extraction tests."""
+    doc = MagicMock()
+    doc.id = doc_id
+    doc.file_path = file_path
+    doc.doc_type.value = doc_type_value
+    doc.application_id = application_id
+    doc.status = status
+    doc.quality_flags = None
+    return doc
+
+
+def _llm_response(
+    extractions=None,
+    quality_flags=None,
+    detected_doc_type="w2",
+):
+    """Build a JSON string matching the expected LLM output."""
+    return json.dumps(
+        {
+            "extractions": extractions
+            or [
+                {
+                    "field_name": "employer_name",
+                    "field_value": "Acme Corp",
+                    "confidence": 0.95,
+                    "source_page": 1,
+                },
+                {
+                    "field_name": "wages",
+                    "field_value": "85000",
+                    "confidence": 0.90,
+                    "source_page": 1,
+                },
+            ],
+            "quality_flags": quality_flags or [],
+            "detected_doc_type": detected_doc_type,
+        }
+    )
+
+
+# Minimal valid PDF (1 page with text "Hello World")
+_MINIMAL_PDF = None
+
+
+def _get_minimal_pdf():
+    """Create a minimal valid PDF with text using pymupdf."""
+    global _MINIMAL_PDF
+    if _MINIMAL_PDF is None:
+        import fitz
+
+        pdf = fitz.open()
+        page = pdf.new_page()
+        page.insert_text((72, 72), "Hello World employer_name Acme Corp wages 85000 tax_year 2025")
+        _MINIMAL_PDF = pdf.tobytes()
+        pdf.close()
+    return _MINIMAL_PDF
+
+
+def _get_blank_pdf():
+    """Create a valid PDF with no text (simulates scanned doc)."""
+    import fitz
+
+    pdf = fitz.open()
+    pdf.new_page()
+    data = pdf.tobytes()
+    pdf.close()
+    return data
+
+
+# ---------------------------------------------------------------------------
+# JSON fence stripping
+# ---------------------------------------------------------------------------
+
+
+class TestStripJsonFences:
+    """_strip_json_fences handles markdown code fences around JSON."""
+
+    def test_clean_json_unchanged(self):
+        raw = '{"extractions": []}'
+        assert _strip_json_fences(raw) == raw
+
+    def test_strips_json_fence(self):
+        fenced = '```json\n{"key": "value"}\n```'
+        assert _strip_json_fences(fenced) == '{"key": "value"}'
+
+    def test_strips_plain_fence(self):
+        fenced = '```\n{"key": "value"}\n```'
+        assert _strip_json_fences(fenced) == '{"key": "value"}'
+
+    def test_strips_with_surrounding_whitespace(self):
+        fenced = '  \n```json\n{"key": "value"}\n```\n  '
+        assert _strip_json_fences(fenced) == '{"key": "value"}'
+
+    def test_non_json_fence_left_alone(self):
+        fenced = '```python\nprint("hello")\n```'
+        # Doesn't match our pattern (only strips json or no-lang fences)
+        assert "print" in _strip_json_fences(fenced)
+
+
+# ---------------------------------------------------------------------------
+# PDF text extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromPdf:
+    """pymupdf text extraction from PDF bytes."""
+
+    def test_extract_text_from_pdf(self):
+        svc = ExtractionService()
+        result = svc._extract_text_from_pdf(_get_minimal_pdf())
+        assert result is not None
+        assert "Hello World" in result
+        assert len(result) >= 50
+
+    def test_corrupted_pdf_returns_none(self):
+        svc = ExtractionService()
+        result = svc._extract_text_from_pdf(b"not a pdf at all")
+        assert result is None
+
+    def test_blank_pdf_returns_short_text(self):
+        svc = ExtractionService()
+        result = svc._extract_text_from_pdf(_get_blank_pdf())
+        assert result is not None
+        assert len(result) < 50
+
+
+# ---------------------------------------------------------------------------
+# Scanned PDF fallback
+# ---------------------------------------------------------------------------
+
+
+class TestScannedPdfFallback:
+    """Scanned PDFs (no text layer) fall back to image extraction."""
+
+    @pytest.mark.asyncio
+    async def test_scanned_pdf_falls_back_to_image_extraction(self):
+        svc = ExtractionService()
+        blank_pdf = _get_blank_pdf()
+
+        with patch.object(svc, "_extract_image_via_llm", new_callable=AsyncMock) as mock_vision:
+            mock_vision.return_value = {
+                "extractions": [
+                    {
+                        "field_name": "employer_name",
+                        "field_value": "Acme",
+                        "confidence": 0.8,
+                        "source_page": 1,
+                    }
+                ],
+                "quality_flags": [],
+                "detected_doc_type": "w2",
+            }
+            result = await svc._process_pdf(blank_pdf, "w2")
+
+        assert result is not None
+        assert result["extractions"][0]["field_name"] == "employer_name"
+        mock_vision.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# LLM extraction
+# ---------------------------------------------------------------------------
+
+
+class TestLlmExtraction:
+    """LLM-based text extraction."""
+
+    @pytest.mark.asyncio
+    async def test_extract_via_llm_returns_structured_data(self):
+        svc = ExtractionService()
+        with patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = _llm_response()
+            result = await svc._extract_via_llm("some document text", "w2")
+
+        assert result is not None
+        assert len(result["extractions"]) == 2
+        assert result["extractions"][0]["field_name"] == "employer_name"
+
+    @pytest.mark.asyncio
+    async def test_extract_via_llm_handles_malformed_json(self):
+        svc = ExtractionService()
+        with patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = "not valid json {{"
+            result = await svc._extract_via_llm("some document text", "w2")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_via_llm_strips_markdown_fences(self):
+        """LLM wraps JSON in ```json ... ``` fences -> still parses correctly."""
+        svc = ExtractionService()
+        fenced = "```json\n" + _llm_response() + "\n```"
+        with patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = fenced
+            result = await svc._extract_via_llm("some document text", "w2")
+
+        assert result is not None
+        assert len(result["extractions"]) == 2
+        assert result["extractions"][0]["field_name"] == "employer_name"
+
+    @pytest.mark.asyncio
+    async def test_extract_via_llm_strips_plain_fences(self):
+        """LLM wraps JSON in ``` ... ``` fences (no language tag) -> still parses."""
+        svc = ExtractionService()
+        fenced = "```\n" + _llm_response() + "\n```"
+        with patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = fenced
+            result = await svc._extract_via_llm("some document text", "w2")
+
+        assert result is not None
+        assert result["extractions"][0]["field_name"] == "employer_name"
+
+    @pytest.mark.asyncio
+    async def test_llm_returns_empty_extractions(self):
+        """Empty extractions list from LLM -> pipeline sets unreadable + FAILED."""
+        svc = ExtractionService()
+
+        mock_doc = _make_mock_doc(file_path="101/1/test.pdf")
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()  # session.add() is synchronous
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.return_value = json.dumps(
+                {
+                    "extractions": [],
+                    "quality_flags": [],
+                    "detected_doc_type": "w2",
+                }
+            )
+
+            await svc.process_document(1)
+
+        assert mock_doc.status.name == "PROCESSING_FAILED" or mock_doc.status == "PROCESSING_FAILED"
+        flags = json.loads(mock_doc.quality_flags)
+        assert "unreadable" in flags
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestProcessDocumentPipeline:
+    """Full process_document pipeline with mocked dependencies."""
+
+    @pytest.mark.asyncio
+    async def test_process_document_pdf_happy_path(self):
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc()
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.return_value = _llm_response()
+
+            await svc.process_document(1)
+
+        # Document should be marked PROCESSING_COMPLETE
+        from db.enums import DocumentStatus
+
+        assert mock_doc.status == DocumentStatus.PROCESSING_COMPLETE
+        mock_session.commit.assert_called()
+        # Extractions should have been added
+        assert mock_session.add.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_process_document_image_happy_path(self):
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc(file_path="101/1/photo.jpg")
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=b"\xff\xd8\xff fake jpeg")
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.return_value = _llm_response()
+
+            await svc.process_document(1)
+
+        from db.enums import DocumentStatus
+
+        assert mock_doc.status == DocumentStatus.PROCESSING_COMPLETE
+
+    @pytest.mark.asyncio
+    async def test_process_document_sets_failed_on_error(self):
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc()
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.side_effect = RuntimeError("LLM connection failed")
+
+            await svc.process_document(1)
+
+        from db.enums import DocumentStatus
+
+        assert mock_doc.status == DocumentStatus.PROCESSING_FAILED
+
+    @pytest.mark.asyncio
+    async def test_process_document_sets_failed_on_bad_request(self):
+        """Provider rejects request (e.g. unsupported response_format) -> PROCESSING_FAILED."""
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc()
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        # Simulate the exact error we hit with LM Studio
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.headers = {}
+        mock_response.json.return_value = {
+            "error": "'response_format.type' must be 'json_schema' or 'text'"
+        }
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.side_effect = BadRequestError(
+                message="'response_format.type' must be 'json_schema' or 'text'",
+                response=mock_response,
+                body={"error": "'response_format.type' must be 'json_schema' or 'text'"},
+            )
+
+            await svc.process_document(1)
+
+        from db.enums import DocumentStatus
+
+        assert mock_doc.status == DocumentStatus.PROCESSING_FAILED
+
+
+# ---------------------------------------------------------------------------
+# HMDA filter
+# ---------------------------------------------------------------------------
+
+
+class TestHmdaFilter:
+    """HMDA demographic field separation."""
+
+    def test_hmda_filter_separates_demographic_fields(self):
+        svc = ExtractionService()
+        extractions = [
+            {"field_name": "employer_name", "field_value": "Acme Corp"},
+            {"field_name": "wages", "field_value": "85000"},
+            {"field_name": "race", "field_value": "Asian"},
+            {"field_name": "ethnicity", "field_value": "Not Hispanic"},
+            {"field_name": "sex", "field_value": "Male"},
+        ]
+        lending, demographic = svc._filter_hmda_fields(extractions)
+        assert len(lending) == 2
+        assert len(demographic) == 3
+        assert all(e["field_name"] in ("employer_name", "wages") for e in lending)
+        assert all(e["field_name"] in ("race", "ethnicity", "sex") for e in demographic)
+
+    def test_hmda_filter_normalizes_llm_field_names(self):
+        """LLMs return space/hyphen-separated names; filter must still catch them."""
+        svc = ExtractionService()
+        extractions = [
+            {"field_name": "employer_name", "field_value": "Acme Corp"},
+            {"field_name": "Marital Status", "field_value": "Married"},
+            {"field_name": "National Origin", "field_value": "US"},
+            {"field_name": "Age-Group", "field_value": "30-40"},
+        ]
+        lending, demographic = svc._filter_hmda_fields(extractions)
+        assert len(lending) == 1
+        assert lending[0]["field_name"] == "employer_name"
+        assert len(demographic) == 3
+
+    def test_hmda_no_demographics_no_audit(self):
+        svc = ExtractionService()
+        extractions = [
+            {"field_name": "employer_name", "field_value": "Acme Corp"},
+            {"field_name": "wages", "field_value": "85000"},
+        ]
+        lending, demographic = svc._filter_hmda_fields(extractions)
+        assert len(lending) == 2
+        assert len(demographic) == 0
+
+
+class TestHmdaRouting:
+    """HMDA data routing to compliance schema and audit logging.
+
+    The actual routing lives in services/compliance/hmda.py (HMDA isolation).
+    These tests mock ComplianceSessionLocal at that module path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hmda_routes_to_compliance_schema(self):
+        from src.services.compliance.hmda import route_extraction_demographics
+
+        demographic_extractions = [
+            {"field_name": "race", "field_value": "Asian"},
+            {"field_name": "sex", "field_value": "Male"},
+        ]
+
+        mock_compliance_session = AsyncMock()
+        mock_compliance_session.add = MagicMock()
+
+        with patch("src.services.compliance.hmda.ComplianceSessionLocal") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_compliance_session)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await route_extraction_demographics(1, 101, demographic_extractions)
+
+        # Should have added HmdaDemographic + AuditEvent
+        assert mock_compliance_session.add.call_count == 2
+        mock_compliance_session.commit.assert_called_once()
+
+        # Check the HmdaDemographic was created with correct fields
+        hmda_call = mock_compliance_session.add.call_args_list[0]
+        hmda_obj = hmda_call[0][0]
+        assert hmda_obj.application_id == 101
+        assert hmda_obj.collection_method == "document_extraction"
+        assert hmda_obj.race == "Asian"
+        assert hmda_obj.sex == "Male"
+
+    @pytest.mark.asyncio
+    async def test_hmda_exclusion_creates_audit_event(self):
+        from src.services.compliance.hmda import route_extraction_demographics
+
+        demographic_extractions = [
+            {"field_name": "race", "field_value": "Asian"},
+        ]
+
+        mock_compliance_session = AsyncMock()
+        mock_compliance_session.add = MagicMock()
+
+        with patch("src.services.compliance.hmda.ComplianceSessionLocal") as mock_cls:
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_compliance_session)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await route_extraction_demographics(1, 101, demographic_extractions)
+
+        # Second add call is the AuditEvent
+        audit_call = mock_compliance_session.add.call_args_list[1]
+        audit_obj = audit_call[0][0]
+        assert audit_obj.event_type == "hmda_document_extraction"
+        assert audit_obj.application_id == 101
+        event_data = json.loads(audit_obj.event_data)
+        assert event_data["document_id"] == 1
+        assert event_data["excluded_fields"][0]["field_name"] == "race"
+        assert event_data["detection_method"] == "keyword_match"
+        assert event_data["routed_to"] == "hmda.demographics"
+
+
+# ---------------------------------------------------------------------------
+# Quality flags
+# ---------------------------------------------------------------------------
+
+
+class TestQualityFlags:
+    """Quality flag persistence and document type mismatch detection."""
+
+    @pytest.mark.asyncio
+    async def test_quality_flags_stored_on_document(self):
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc()
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_llm.return_value = _llm_response(quality_flags=["blurry", "incomplete"])
+
+            await svc.process_document(1)
+
+        flags = json.loads(mock_doc.quality_flags)
+        assert "blurry" in flags
+        assert "incomplete" in flags
+
+    @pytest.mark.asyncio
+    async def test_document_type_mismatch_detected(self):
+        svc = ExtractionService()
+        mock_doc = _make_mock_doc()
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_doc
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        mock_storage = MagicMock()
+        mock_storage.download_file = AsyncMock(return_value=_get_minimal_pdf())
+
+        with (
+            patch("src.services.extraction.SessionLocal") as mock_session_cls,
+            patch("src.services.extraction.get_storage_service", return_value=mock_storage),
+            patch("src.services.extraction.get_completion", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            # Declared type is w2 but LLM detects pay_stub
+            mock_llm.return_value = _llm_response(detected_doc_type="pay_stub")
+
+            await svc.process_document(1)
+
+        flags = json.loads(mock_doc.quality_flags)
+        assert "document_type_mismatch" in flags

--- a/packages/api/uv.lock
+++ b/packages/api/uv.lock
@@ -68,6 +68,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pymupdf" },
     { name = "pyyaml" },
     { name = "sqladmin" },
     { name = "sqlalchemy" },
@@ -105,6 +106,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.8.0" },
+    { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1650,6 +1652,21 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/0c/40dda0cc4bd2220a2ef75f8c53dd7d8ed1e29681fcb3df75db6ee9677a7e/pymupdf-1.27.1.tar.gz", hash = "sha256:4afbde0769c336717a149ab0de3330dcb75378f795c1a8c5af55c1a628b17d55", size = 85303479, upload-time = "2026-02-12T08:29:17.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/19/fde6ea4712a904b65e8f41124a0e4233879b87a770fe6a8ce857964de6d5/pymupdf-1.27.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bee9f95512f9556dbf2cacfd1413c61b29a55baa07fa7f8fc83d221d8419888a", size = 23986707, upload-time = "2026-02-11T15:03:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c2/070dff91ad3f1bc16fd6c6ceff23495601fcce4c92d28be534417596418a/pymupdf-1.27.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3de95a0889395b0966fafd11b94980b7543a816e89dd1c218597a08543ac3415", size = 23263493, upload-time = "2026-02-11T15:03:45.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/db/937377f4b3e0fbf6273c17436a49f7db17df1a46b1be9e26653b6fafc0e1/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2c9d9353b840040cbc724341f4095fb7e2cc1a12a9147d0ec1a0a79f5d773147", size = 24317651, upload-time = "2026-02-11T22:33:38.967Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d5/c701cf2d0cdd6e5d6bca3ca9188d7f5d7ce3ae67dd1368d658cd4bae2707/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:aeaed76e72cbc061149a825ab0811c5f4752970c56591c2938c5042ec06b26e1", size = 24945742, upload-time = "2026-02-11T15:04:06.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Two-stage document extraction pipeline: pymupdf text extraction with LLM vision fallback for scanned PDFs and images
- Structured field extraction via `capable_large` LLM tier with doc-type-specific prompts, quality assessment flags (blurry, incomplete, wrong_period, document_type_mismatch, unsigned)
- HMDA demographic field filter routes captured demographic data (race, ethnicity, sex, marital status) to compliance schema (`hmda.demographics` with `collection_method = document_extraction`) with full audit trail, excluded from lending-path `document_extractions`
- Extraction prompts instruct LLM to extract demographic fields alongside domain fields so the HMDA filter can catch and route them
- HMDA keyword matching normalizes field name separators (space/hyphen to underscore) to handle LLM output variations like "Marital Status" vs "marital_status"
- Markdown code fence stripping for LLM responses that wrap JSON in fences
- Background processing via `asyncio.create_task()` fired after upload 201 response
- S3 path-style addressing fix for MinIO compatibility (botocore S3 Accelerate conflict)
- 25 unit tests + 2 functional tests covering PDF/image pipelines, HMDA filtering, quality flags, fence stripping, error handling

## Stories
S-2-F5-01 (extraction produces structured data), S-2-F5-02 (quality assessment flags), S-2-F5-03 (HMDA demographic filter), S-2-F5-04 (exclusion audit logging)

## Files changed
| Action | File |
|--------|------|
| Modify | `pyproject.toml` (add pymupdf) |
| Modify | `src/services/storage.py` (add download_file + S3 path-style fix) |
| Create | `src/services/extraction_prompts.py` |
| Create | `src/services/extraction.py` |
| Modify | `src/services/compliance/hmda.py` (add route_extraction_demographics) |
| Modify | `src/routes/documents.py` (add background task dispatch) |
| Modify | `src/main.py` (add extraction service init) |
| Create | `tests/test_extraction.py` (25 unit tests) |
| Create | `tests/functional/test_extraction_flow.py` (2 functional tests) |
| Modify | `tests/functional/conftest.py` (extraction mock fixture) |
| Modify | `tests/functional/mock_db.py` (fix session.add warning) |
| Modify | `tests/test_document_upload.py` (extraction mock + assertion) |
| Modify | `.gitignore` (add agent-memory/) |

## Test plan
- [x] 25 extraction unit tests pass
- [x] 2 functional tests pass
- [x] All 227 tests pass (full regression)
- [x] Ruff lint clean
- [x] HMDA isolation check passes
- [x] Live smoke test: uploaded W-2 PDF with demographic section, verified extraction completes
- [x] Live HMDA isolation test: demographic fields (race, ethnicity, sex, marital status) routed to `hmda.demographics` with `collection_method=document_extraction`, excluded from `document_extractions`, audit event logged with all excluded field details

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>