### PR TITLE
feat(api,db): co-borrower support + HMDA demographics upsert

### DIFF
--- a/packages/api/src/admin.py
+++ b/packages/api/src/admin.py
@@ -28,8 +28,13 @@ engine = create_engine(_sync_url, echo=False)
 
 
 class BorrowerAdmin(ModelView, model=Borrower):
-    column_list = [Borrower.id, Borrower.first_name, Borrower.last_name, Borrower.email,
-                   Borrower.created_at]
+    column_list = [
+        Borrower.id,
+        Borrower.first_name,
+        Borrower.last_name,
+        Borrower.email,
+        Borrower.created_at,
+    ]
     column_searchable_list = [Borrower.first_name, Borrower.last_name, Borrower.email]
     column_sortable_list = [Borrower.id, Borrower.last_name, Borrower.created_at]
     column_default_sort = [(Borrower.created_at, True)]
@@ -39,9 +44,14 @@ class BorrowerAdmin(ModelView, model=Borrower):
 
 
 class ApplicationAdmin(ModelView, model=Application):
-    column_list = [Application.id, Application.borrower_id, Application.stage,
-                   Application.loan_type, Application.loan_amount, Application.assigned_to,
-                   Application.created_at]
+    column_list = [
+        Application.id,
+        Application.stage,
+        Application.loan_type,
+        Application.loan_amount,
+        Application.assigned_to,
+        Application.created_at,
+    ]
     column_searchable_list = [Application.property_address, Application.assigned_to]
     column_sortable_list = [Application.id, Application.stage, Application.created_at]
     column_default_sort = [(Application.created_at, True)]
@@ -51,17 +61,27 @@ class ApplicationAdmin(ModelView, model=Application):
 
 
 class ApplicationFinancialsAdmin(ModelView, model=ApplicationFinancials):
-    column_list = [ApplicationFinancials.id, ApplicationFinancials.application_id,
-                   ApplicationFinancials.credit_score, ApplicationFinancials.dti_ratio,
-                   ApplicationFinancials.gross_monthly_income]
+    column_list = [
+        ApplicationFinancials.id,
+        ApplicationFinancials.application_id,
+        ApplicationFinancials.credit_score,
+        ApplicationFinancials.dti_ratio,
+        ApplicationFinancials.gross_monthly_income,
+    ]
     name = "Financials"
     name_plural = "Financials"
     icon = "fa-solid fa-dollar-sign"
 
 
 class RateLockAdmin(ModelView, model=RateLock):
-    column_list = [RateLock.id, RateLock.application_id, RateLock.locked_rate,
-                   RateLock.lock_date, RateLock.expiration_date, RateLock.is_active]
+    column_list = [
+        RateLock.id,
+        RateLock.application_id,
+        RateLock.locked_rate,
+        RateLock.lock_date,
+        RateLock.expiration_date,
+        RateLock.is_active,
+    ]
     column_default_sort = [(RateLock.created_at, True)]
     name = "Rate Lock"
     name_plural = "Rate Locks"
@@ -69,8 +89,14 @@ class RateLockAdmin(ModelView, model=RateLock):
 
 
 class ConditionAdmin(ModelView, model=Condition):
-    column_list = [Condition.id, Condition.application_id, Condition.severity,
-                   Condition.status, Condition.issued_by, Condition.created_at]
+    column_list = [
+        Condition.id,
+        Condition.application_id,
+        Condition.severity,
+        Condition.status,
+        Condition.issued_by,
+        Condition.created_at,
+    ]
     column_sortable_list = [Condition.id, Condition.severity, Condition.status]
     column_default_sort = [(Condition.created_at, True)]
     name = "Condition"
@@ -79,8 +105,13 @@ class ConditionAdmin(ModelView, model=Condition):
 
 
 class DecisionAdmin(ModelView, model=Decision):
-    column_list = [Decision.id, Decision.application_id, Decision.decision_type,
-                   Decision.decided_by, Decision.created_at]
+    column_list = [
+        Decision.id,
+        Decision.application_id,
+        Decision.decision_type,
+        Decision.decided_by,
+        Decision.created_at,
+    ]
     column_default_sort = [(Decision.created_at, True)]
     name = "Decision"
     name_plural = "Decisions"
@@ -88,8 +119,14 @@ class DecisionAdmin(ModelView, model=Decision):
 
 
 class DocumentAdmin(ModelView, model=Document):
-    column_list = [Document.id, Document.application_id, Document.doc_type,
-                   Document.status, Document.uploaded_by, Document.created_at]
+    column_list = [
+        Document.id,
+        Document.application_id,
+        Document.doc_type,
+        Document.status,
+        Document.uploaded_by,
+        Document.created_at,
+    ]
     column_searchable_list = [Document.uploaded_by]
     column_sortable_list = [Document.id, Document.doc_type, Document.status]
     column_default_sort = [(Document.created_at, True)]
@@ -99,16 +136,26 @@ class DocumentAdmin(ModelView, model=Document):
 
 
 class DocumentExtractionAdmin(ModelView, model=DocumentExtraction):
-    column_list = [DocumentExtraction.id, DocumentExtraction.document_id,
-                   DocumentExtraction.field_name, DocumentExtraction.confidence]
+    column_list = [
+        DocumentExtraction.id,
+        DocumentExtraction.document_id,
+        DocumentExtraction.field_name,
+        DocumentExtraction.confidence,
+    ]
     name = "Extraction"
     name_plural = "Extractions"
     icon = "fa-solid fa-search"
 
 
 class AuditEventAdmin(ModelView, model=AuditEvent):
-    column_list = [AuditEvent.id, AuditEvent.timestamp, AuditEvent.event_type,
-                   AuditEvent.user_id, AuditEvent.user_role, AuditEvent.application_id]
+    column_list = [
+        AuditEvent.id,
+        AuditEvent.timestamp,
+        AuditEvent.event_type,
+        AuditEvent.user_id,
+        AuditEvent.user_role,
+        AuditEvent.application_id,
+    ]
     column_sortable_list = [AuditEvent.id, AuditEvent.timestamp, AuditEvent.event_type]
     column_default_sort = [(AuditEvent.timestamp, True)]
     can_create = False
@@ -120,8 +167,7 @@ class AuditEventAdmin(ModelView, model=AuditEvent):
 
 
 class DemoDataManifestAdmin(ModelView, model=DemoDataManifest):
-    column_list = [DemoDataManifest.id, DemoDataManifest.seeded_at,
-                   DemoDataManifest.config_hash]
+    column_list = [DemoDataManifest.id, DemoDataManifest.seeded_at, DemoDataManifest.config_hash]
     can_create = False
     can_edit = False
     can_delete = False

--- a/packages/api/src/middleware/pii.py
+++ b/packages/api/src/middleware/pii.py
@@ -54,6 +54,6 @@ def mask_borrower_pii(borrower_dict: dict) -> dict:
 def mask_application_pii(app_dict: dict) -> dict:
     """Apply PII masking to an application dict for CEO-role responses."""
     masked = app_dict.copy()
-    if "borrower" in masked and masked["borrower"] is not None:
-        masked["borrower"] = mask_borrower_pii(masked["borrower"])
+    if "borrowers" in masked:
+        masked["borrowers"] = [mask_borrower_pii(b) for b in masked["borrowers"]]
     return masked

--- a/packages/api/src/routes/hmda.py
+++ b/packages/api/src/routes/hmda.py
@@ -30,7 +30,7 @@ async def collect_hmda(
     Simulated for demonstration purposes -- not legally compliant HMDA collection.
     """
     try:
-        demographic = await collect_demographics(
+        demographic, conflicts = await collect_demographics(
             lending_session=session,
             compliance_session=compliance_session,
             user=user,
@@ -42,4 +42,7 @@ async def collect_hmda(
             detail=str(exc),
         ) from exc
 
-    return HmdaCollectionResponse.model_validate(demographic)
+    response = HmdaCollectionResponse.model_validate(demographic)
+    if conflicts:
+        response = response.model_copy(update={"conflicts": conflicts})
+    return response

--- a/packages/api/src/schemas/application.py
+++ b/packages/api/src/schemas/application.py
@@ -39,6 +39,7 @@ class BorrowerSummary(BaseModel):
     email: str
     ssn_encrypted: str | None = None
     dob: datetime | None = None
+    is_primary: bool = False
 
 
 class ApplicationResponse(BaseModel):
@@ -47,7 +48,6 @@ class ApplicationResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-    borrower_id: int
     stage: ApplicationStage
     loan_type: LoanType | None = None
     property_address: str | None = None
@@ -56,7 +56,7 @@ class ApplicationResponse(BaseModel):
     assigned_to: str | None = None
     created_at: datetime
     updated_at: datetime
-    borrower: BorrowerSummary | None = None
+    borrowers: list[BorrowerSummary] = []
 
 
 class ApplicationListResponse(BaseModel):

--- a/packages/api/src/schemas/document.py
+++ b/packages/api/src/schemas/document.py
@@ -14,6 +14,7 @@ class DocumentResponse(BaseModel):
 
     id: int
     application_id: int
+    borrower_id: int | None = None
     doc_type: DocumentType
     status: DocumentStatus
     quality_flags: str | None = None
@@ -35,6 +36,7 @@ class DocumentUploadResponse(BaseModel):
 
     id: int
     application_id: int
+    borrower_id: int | None = None
     doc_type: DocumentType
     status: DocumentStatus
     file_path: str | None = None

--- a/packages/api/src/schemas/hmda.py
+++ b/packages/api/src/schemas/hmda.py
@@ -10,6 +10,7 @@ class HmdaCollectionRequest(BaseModel):
     """Request body for HMDA demographic data collection."""
 
     application_id: int
+    borrower_id: int | None = None
     race: str | None = None
     ethnicity: str | None = None
     sex: str | None = None
@@ -26,5 +27,7 @@ class HmdaCollectionResponse(BaseModel):
 
     id: int
     application_id: int
+    borrower_id: int | None = None
     collected_at: datetime
+    conflicts: list[dict] | None = None
     status: str = "collected"

--- a/packages/api/src/services/compliance/seed_hmda.py
+++ b/packages/api/src/services/compliance/seed_hmda.py
@@ -40,6 +40,7 @@ async def seed_hmda_demographics(
     for demo_data in application_demographics:
         demographic = HmdaDemographic(
             application_id=demo_data["application_id"],
+            borrower_id=demo_data.get("borrower_id"),
             race=demo_data["race"],
             ethnicity=demo_data["ethnicity"],
             sex=demo_data["sex"],

--- a/packages/api/src/services/extraction.py
+++ b/packages/api/src/services/extraction.py
@@ -111,7 +111,10 @@ class ExtractionService:
                 # Route demographic data to compliance schema
                 if demographic_extractions:
                     await route_extraction_demographics(
-                        document_id, application_id, demographic_extractions
+                        document_id,
+                        application_id,
+                        demographic_extractions,
+                        borrower_id=doc.borrower_id,
                     )
 
                 # Store quality flags

--- a/packages/api/src/services/extraction_prompts.py
+++ b/packages/api/src/services/extraction_prompts.py
@@ -122,8 +122,8 @@ def build_image_extraction_prompt(doc_type: str) -> dict:
             f"Expected document type: {doc_type}\n"
             f"Expected fields: {fields_csv}\n"
             "IMPORTANT: If the document contains any demographic or government "
-            "monitoring information (race, ethnicity, sex, gender, marital status, "
-            "national origin), extract those fields as well.\n"
+            "monitoring information (race, ethnicity, sex, gender, age), "
+            "extract those fields as well.\n"
             "If a field is not found, omit it. Do not guess values."
         ),
     }

--- a/packages/api/src/services/seed/fixtures.py
+++ b/packages/api/src/services/seed/fixtures.py
@@ -38,6 +38,9 @@ MARIA_CHEN_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567803"
 DAVID_PARK_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567804"
 ADMIN_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567805"
 
+# Co-borrower (spouse of Sarah Mitchell)
+JENNIFER_MITCHELL_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567806"
+
 # Fictional borrowers (not in Keycloak -- only used for historical loan data)
 MICHAEL_JOHNSON_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567811"
 EMILY_RODRIGUEZ_ID = "d1a2b3c4-e5f6-7890-abcd-ef1234567812"
@@ -73,6 +76,14 @@ BORROWERS: list[dict] = [
         "email": "sarah.mitchell@example.com",
         "ssn_encrypted": "ENC:293-84-1567",
         "dob": datetime(1988, 6, 15, tzinfo=UTC),
+    },
+    {
+        "keycloak_user_id": JENNIFER_MITCHELL_ID,
+        "first_name": "Jennifer",
+        "last_name": "Mitchell",
+        "email": "jennifer.mitchell@example.com",
+        "ssn_encrypted": "ENC:384-71-2956",
+        "dob": datetime(1990, 2, 8, tzinfo=UTC),
     },
     {
         "keycloak_user_id": "d1a2b3c4-e5f6-7890-abcd-ef1234567811",
@@ -127,6 +138,7 @@ ACTIVE_APPLICATIONS: list[dict] = [
     # --- 3 in APPLICATION stage ---
     {
         "borrower_ref": SARAH_MITCHELL_ID,
+        "co_borrower_refs": [JENNIFER_MITCHELL_ID],
         "stage": ApplicationStage.APPLICATION,
         "loan_type": LoanType.CONVENTIONAL_30,
         "property_address": "1234 Elm Street, Denver, CO 80203",
@@ -277,6 +289,7 @@ ACTIVE_APPLICATIONS: list[dict] = [
     # --- 2 in CONDITIONAL_APPROVAL stage ---
     {
         "borrower_ref": MICHAEL_JOHNSON_ID,
+        "co_borrower_refs": [EMILY_RODRIGUEZ_ID],
         "stage": ApplicationStage.CONDITIONAL_APPROVAL,
         "loan_type": LoanType.JUMBO,
         "property_address": "3456 Cedar Boulevard, Cherry Hills Village, CO 80113",
@@ -657,6 +670,7 @@ def compute_config_hash() -> str:
             "historical_count": len(HISTORICAL_LOANS),
             "hmda_count": len(HMDA_DEMOGRAPHICS),
             "borrower_ids": [b["keycloak_user_id"] for b in BORROWERS],
+            "co_borrower_apps": sum(1 for a in ACTIVE_APPLICATIONS if a.get("co_borrower_refs")),
         },
         sort_keys=True,
     )

--- a/packages/api/tests/functional/data_factory.py
+++ b/packages/api/tests/functional/data_factory.py
@@ -55,6 +55,15 @@ def make_borrower_michael() -> MagicMock:
     return b
 
 
+def _make_app_borrower(borrower, *, is_primary=True) -> MagicMock:
+    """Build a mock ApplicationBorrower junction object."""
+    ab = MagicMock()
+    ab.borrower = borrower
+    ab.borrower_id = borrower.id
+    ab.is_primary = is_primary
+    return ab
+
+
 # ---------------------------------------------------------------------------
 # Applications
 # ---------------------------------------------------------------------------
@@ -64,7 +73,6 @@ def make_app_sarah_1() -> MagicMock:
     """App 101: Sarah, APPLICATION stage, assigned to LO."""
     app = MagicMock()
     app.id = 101
-    app.borrower_id = 1
     app.stage = ApplicationStage.APPLICATION
     app.loan_type = LoanType.CONVENTIONAL_30
     app.property_address = "123 Oak Street"
@@ -73,7 +81,7 @@ def make_app_sarah_1() -> MagicMock:
     app.assigned_to = LO_USER_ID
     app.created_at = datetime(2026, 1, 10, tzinfo=UTC)
     app.updated_at = datetime(2026, 1, 15, tzinfo=UTC)
-    app.borrower = make_borrower_sarah()
+    app.application_borrowers = [_make_app_borrower(make_borrower_sarah())]
     return app
 
 
@@ -81,7 +89,6 @@ def make_app_sarah_2() -> MagicMock:
     """App 102: Sarah, INQUIRY stage, unassigned."""
     app = MagicMock()
     app.id = 102
-    app.borrower_id = 1
     app.stage = ApplicationStage.INQUIRY
     app.loan_type = None
     app.property_address = None
@@ -90,7 +97,7 @@ def make_app_sarah_2() -> MagicMock:
     app.assigned_to = None
     app.created_at = datetime(2026, 2, 1, tzinfo=UTC)
     app.updated_at = datetime(2026, 2, 1, tzinfo=UTC)
-    app.borrower = make_borrower_sarah()
+    app.application_borrowers = [_make_app_borrower(make_borrower_sarah())]
     return app
 
 
@@ -98,7 +105,6 @@ def make_app_michael() -> MagicMock:
     """App 103: Michael, UNDERWRITING stage, assigned to LO."""
     app = MagicMock()
     app.id = 103
-    app.borrower_id = 2
     app.stage = ApplicationStage.UNDERWRITING
     app.loan_type = LoanType.FHA
     app.property_address = "456 Maple Avenue"
@@ -107,7 +113,7 @@ def make_app_michael() -> MagicMock:
     app.assigned_to = LO_USER_ID
     app.created_at = datetime(2026, 1, 20, tzinfo=UTC)
     app.updated_at = datetime(2026, 2, 10, tzinfo=UTC)
-    app.borrower = make_borrower_michael()
+    app.application_borrowers = [_make_app_borrower(make_borrower_michael())]
     return app
 
 
@@ -146,6 +152,7 @@ def make_document(**overrides) -> MagicMock:
     doc = MagicMock()
     doc.id = overrides.get("id", 1)
     doc.application_id = overrides.get("application_id", 101)
+    doc.borrower_id = overrides.get("borrower_id", 1)
     doc.doc_type = overrides.get("doc_type", DocumentType.W2)
     doc.status = overrides.get("status", DocumentStatus.UPLOADED)
     doc.quality_flags = overrides.get("quality_flags", None)

--- a/packages/api/tests/functional/test_admin_flow.py
+++ b/packages/api/tests/functional/test_admin_flow.py
@@ -33,7 +33,7 @@ class TestAdminFullAccess:
         resp = client.get("/api/applications/101")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_patch_application(self, make_client):
         app = make_app_sarah_1()

--- a/packages/api/tests/functional/test_borrower_flow.py
+++ b/packages/api/tests/functional/test_borrower_flow.py
@@ -37,7 +37,7 @@ class TestBorrowerSarahVisibility:
         data = resp.json()
         assert data["id"] == 101
         # PII is visible to borrower (it's their own data)
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_out_of_scope_returns_404(self, make_client):
         """Sarah cannot see Michael's app -- returns 404 not 403."""

--- a/packages/api/tests/functional/test_ceo_flow.py
+++ b/packages/api/tests/functional/test_ceo_flow.py
@@ -27,11 +27,11 @@ class TestCeoPiiMasking:
         assert data["count"] == 3
 
         for item in data["data"]:
-            borrower = item.get("borrower")
-            if borrower and borrower.get("ssn_encrypted"):
-                assert borrower["ssn_encrypted"].startswith("***-**-")
-            if borrower and borrower.get("dob"):
-                assert "**" in borrower["dob"]
+            for borrower in item.get("borrowers", []):
+                if borrower.get("ssn_encrypted"):
+                    assert borrower["ssn_encrypted"].startswith("***-**-")
+                if borrower.get("dob"):
+                    assert "**" in borrower["dob"]
 
     def test_get_application_ssn_masked(self, make_client):
         app = make_app_sarah_1()
@@ -40,7 +40,7 @@ class TestCeoPiiMasking:
         resp = client.get("/api/applications/101")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["borrower"]["ssn_encrypted"] == "***-**-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "***-**-6789"
 
     def test_get_application_dob_masked(self, make_client):
         app = make_app_sarah_1()
@@ -48,7 +48,7 @@ class TestCeoPiiMasking:
 
         resp = client.get("/api/applications/101")
         data = resp.json()
-        assert data["borrower"]["dob"].startswith("1990-**")
+        assert data["borrowers"][0]["dob"].startswith("1990-**")
 
 
 class TestCeoDocumentRestriction:

--- a/packages/api/tests/functional/test_cross_persona_isolation.py
+++ b/packages/api/tests/functional/test_cross_persona_isolation.py
@@ -80,37 +80,37 @@ class TestPiiByRole:
         app = make_app_sarah_1()
         client = make_client(borrower_sarah(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_loan_officer_sees_full_ssn(self, make_client):
         app = make_app_sarah_1()
         client = make_client(loan_officer(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_underwriter_sees_full_ssn(self, make_client):
         app = make_app_sarah_1()
         client = make_client(underwriter(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_admin_sees_full_ssn(self, make_client):
         app = make_app_sarah_1()
         client = make_client(admin(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_ceo_sees_masked_ssn(self, make_client):
         app = make_app_sarah_1()
         client = make_client(ceo(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["ssn_encrypted"] == "***-**-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "***-**-6789"
 
     def test_ceo_sees_masked_dob(self, make_client):
         app = make_app_sarah_1()
         client = make_client(ceo(), make_mock_session(single=app))
         data = client.get("/api/applications/101").json()
-        assert data["borrower"]["dob"].startswith("1990-**")
+        assert data["borrowers"][0]["dob"].startswith("1990-**")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/functional/test_loan_officer_flow.py
+++ b/packages/api/tests/functional/test_loan_officer_flow.py
@@ -35,7 +35,7 @@ class TestLoanOfficerVisibility:
         data = resp.json()
         assert data["id"] == 101
         # LO sees full PII
-        assert data["borrower"]["ssn_encrypted"] == "123-45-6789"
+        assert data["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
     def test_unassigned_returns_404(self, make_client):
         """App 102 is unassigned, so LO gets 404."""

--- a/packages/api/tests/functional/test_underwriter_flow.py
+++ b/packages/api/tests/functional/test_underwriter_flow.py
@@ -33,7 +33,7 @@ class TestUnderwriterVisibility:
         resp = client.get("/api/applications/103")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["borrower"]["ssn_encrypted"] == "987-65-4321"
+        assert data["borrowers"][0]["ssn_encrypted"] == "987-65-4321"
 
 
 class TestUnderwriterCanUpdate:

--- a/packages/api/tests/test_document_upload.py
+++ b/packages/api/tests/test_document_upload.py
@@ -36,7 +36,6 @@ def _make_mock_application(app_id: int = 100):
     """Build a mock Application ORM object."""
     app = MagicMock()
     app.id = app_id
-    app.borrower_id = 1
     return app
 
 
@@ -67,9 +66,13 @@ def _make_upload_app(user: UserContext, *, app_found: bool = True):
 
     if app_found:
         mock_app = _make_mock_application()
-        mock_result = MagicMock()
-        mock_result.unique.return_value.scalar_one_or_none.return_value = mock_app
-        mock_session.execute = AsyncMock(return_value=mock_result)
+        # First execute: app lookup (uses .unique().scalar_one_or_none())
+        app_result = MagicMock()
+        app_result.unique.return_value.scalar_one_or_none.return_value = mock_app
+        # Second execute: primary borrower lookup (uses .scalar_one_or_none())
+        borrower_result = MagicMock()
+        borrower_result.scalar_one_or_none.return_value = 1  # primary borrower_id
+        mock_session.execute = AsyncMock(side_effect=[app_result, borrower_result])
     else:
         mock_result = MagicMock()
         mock_result.unique.return_value.scalar_one_or_none.return_value = None

--- a/packages/api/tests/test_models.py
+++ b/packages/api/tests/test_models.py
@@ -9,7 +9,7 @@ def test_application_relationships():
     from db import Application
 
     rel_names = {r.key for r in Application.__mapper__.relationships}
-    assert "borrower" in rel_names
+    assert "application_borrowers" in rel_names
     assert "financials" in rel_names
     assert "rate_locks" in rel_names
     assert "conditions" in rel_names

--- a/packages/api/tests/test_rbac.py
+++ b/packages/api/tests/test_rbac.py
@@ -18,29 +18,43 @@ def test_mask_dob_iso_datetime():
     assert mask_dob("1990-03-15T00:00:00") == "1990-**-**"
 
 
-def test_mask_application_pii_masks_borrower():
-    """Application-level masking applies to nested borrower fields."""
+def test_mask_application_pii_masks_borrowers_list():
+    """Application-level masking applies to borrowers list."""
     app_dict = {
         "id": 1,
-        "borrower": {
-            "id": 10,
-            "first_name": "Sarah",
-            "last_name": "Mitchell",
-            "ssn_encrypted": "123-45-6789",
-            "dob": "1990-03-15T00:00:00",
-            "email": "sarah@example.com",
-        },
+        "borrowers": [
+            {
+                "id": 10,
+                "first_name": "Sarah",
+                "last_name": "Mitchell",
+                "ssn_encrypted": "123-45-6789",
+                "dob": "1990-03-15T00:00:00",
+                "email": "sarah@example.com",
+                "is_primary": True,
+            },
+            {
+                "id": 11,
+                "first_name": "Jennifer",
+                "last_name": "Mitchell",
+                "ssn_encrypted": "987-65-4321",
+                "dob": "1992-08-22T00:00:00",
+                "email": "jennifer@example.com",
+                "is_primary": False,
+            },
+        ],
         "stage": "inquiry",
     }
     masked = mask_application_pii(app_dict)
     # Names stay visible
-    assert masked["borrower"]["first_name"] == "Sarah"
-    assert masked["borrower"]["last_name"] == "Mitchell"
+    assert masked["borrowers"][0]["first_name"] == "Sarah"
+    assert masked["borrowers"][1]["first_name"] == "Jennifer"
     # PII is masked
-    assert masked["borrower"]["ssn_encrypted"] == "***-**-6789"
-    assert masked["borrower"]["dob"] == "1990-**-**"
+    assert masked["borrowers"][0]["ssn_encrypted"] == "***-**-6789"
+    assert masked["borrowers"][0]["dob"] == "1990-**-**"
+    assert masked["borrowers"][1]["ssn_encrypted"] == "***-**-4321"
+    assert masked["borrowers"][1]["dob"] == "1992-**-**"
     # Original not mutated
-    assert app_dict["borrower"]["ssn_encrypted"] == "123-45-6789"
+    assert app_dict["borrowers"][0]["ssn_encrypted"] == "123-45-6789"
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +95,111 @@ def test_prospect_cannot_access_applications(monkeypatch):
     client = TestClient(app)
     resp = client.get("/api/applications/")
     assert resp.status_code == 403
+
+
+def test_co_borrower_sees_shared_application(monkeypatch):
+    """Co-borrower (non-primary) sees application via junction table scope."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from db import get_db
+    from db.enums import ApplicationStage, LoanType, UserRole
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from src.core.config import settings
+    from src.middleware.auth import get_current_user
+    from src.routes.applications import router
+    from src.schemas.auth import DataScope, UserContext
+
+    monkeypatch.setattr(settings, "AUTH_DISABLED", False)
+
+    # Co-borrower (not the primary on this app)
+    co_borrower = UserContext(
+        user_id="coborrower-1",
+        role=UserRole.BORROWER,
+        email="coborrower@example.com",
+        name="Co-Borrower",
+        data_scope=DataScope(own_data_only=True, user_id="coborrower-1"),
+    )
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/applications")
+
+    async def fake_user():
+        return co_borrower
+
+    mock_session = AsyncMock()
+
+    # Build mock application with both primary and co-borrower in junction table
+    mock_app = MagicMock()
+    mock_app.id = 101
+    mock_app.stage = ApplicationStage.APPLICATION
+    mock_app.loan_type = LoanType.CONVENTIONAL_30
+    mock_app.property_address = "123 Test St"
+    mock_app.loan_amount = 300000
+    mock_app.property_value = 400000
+    mock_app.assigned_to = None
+    mock_app.created_at = "2026-01-01T00:00:00+00:00"
+    mock_app.updated_at = "2026-01-01T00:00:00+00:00"
+
+    # Junction entries: primary + co-borrower
+    primary_borrower = MagicMock()
+    primary_borrower.id = 1
+    primary_borrower.first_name = "Primary"
+    primary_borrower.last_name = "Borrower"
+    primary_borrower.email = "primary@example.com"
+    primary_borrower.ssn_encrypted = None
+    primary_borrower.dob = None
+
+    co_borrower_obj = MagicMock()
+    co_borrower_obj.id = 2
+    co_borrower_obj.first_name = "Co"
+    co_borrower_obj.last_name = "Borrower"
+    co_borrower_obj.email = "coborrower@example.com"
+    co_borrower_obj.ssn_encrypted = None
+    co_borrower_obj.dob = None
+
+    ab_primary = MagicMock()
+    ab_primary.borrower = primary_borrower
+    ab_primary.is_primary = True
+
+    ab_co = MagicMock()
+    ab_co.borrower = co_borrower_obj
+    ab_co.is_primary = False
+
+    mock_app.application_borrowers = [ab_primary, ab_co]
+    mock_app.financials = None
+
+    # Mock session returns: count=1, then the app
+    count_result = MagicMock()
+    count_result.scalar.return_value = 1
+    list_result = MagicMock()
+    list_result.unique.return_value.scalars.return_value.all.return_value = [mock_app]
+    mock_session.execute = AsyncMock(side_effect=[count_result, list_result])
+
+    async def fake_db():
+        yield mock_session
+
+    app.dependency_overrides[get_current_user] = fake_user
+    app.dependency_overrides[get_db] = fake_db
+
+    client = TestClient(app)
+    resp = client.get("/api/applications/")
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert data["count"] == 1
+    apps = data["data"]
+    assert len(apps) == 1
+    assert apps[0]["id"] == 101
+    # Both borrowers in list with correct is_primary flags
+    borrowers = apps[0]["borrowers"]
+    assert len(borrowers) == 2
+    primary_list = [b for b in borrowers if b["is_primary"]]
+    co_list = [b for b in borrowers if not b["is_primary"]]
+    assert len(primary_list) == 1
+    assert len(co_list) == 1
+    assert co_list[0]["first_name"] == "Co"
 
 
 def test_borrower_cannot_patch_application(monkeypatch):

--- a/packages/api/tests/test_seed.py
+++ b/packages/api/tests/test_seed.py
@@ -53,8 +53,8 @@ def _make_app(user: UserContext = _ADMIN_USER):
 
 
 def test_fixture_borrower_count():
-    """Fixture defines 6 borrowers (1 real + 5 fictional)."""
-    assert len(BORROWERS) == 6
+    """Fixture defines 7 borrowers (1 real + 1 co-borrower + 5 fictional)."""
+    assert len(BORROWERS) == 7
 
 
 def test_fixture_active_application_count():
@@ -147,7 +147,7 @@ async def test_seed_creates_borrowers():
     from db import Borrower
 
     borrower_adds = [o for o in added_objects if isinstance(o, Borrower)]
-    assert len(borrower_adds) == 6
+    assert len(borrower_adds) == 7
 
     from src.services.seed.fixtures import MICHAEL_JOHNSON_ID, SARAH_MITCHELL_ID
 

--- a/packages/db/alembic/versions/b3c4d5e6f7a8_hmda_demographics_per_borrower.py
+++ b/packages/db/alembic/versions/b3c4d5e6f7a8_hmda_demographics_per_borrower.py
@@ -1,0 +1,66 @@
+# This project was developed with assistance from AI tools.
+"""hmda demographics per-borrower: add borrower_id, updated_at, unique constraint
+
+Revision ID: b3c4d5e6f7a8
+Revises: f6a7b8c9d0e1
+Create Date: 2026-02-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "b3c4d5e6f7a8"
+down_revision = "f6a7b8c9d0e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add borrower_id column (no FK -- hmda schema cannot reference public.borrowers)
+    op.add_column(
+        "demographics",
+        sa.Column("borrower_id", sa.Integer(), nullable=True),
+        schema="hmda",
+    )
+    op.create_index(
+        "ix_demographics_borrower_id",
+        "demographics",
+        ["borrower_id"],
+        schema="hmda",
+    )
+
+    # Add updated_at column
+    op.add_column(
+        "demographics",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        schema="hmda",
+    )
+
+    # Unique constraint on (application_id, borrower_id)
+    # PostgreSQL treats NULLs as distinct, so legacy rows with NULL borrower_id won't conflict
+    op.create_unique_constraint(
+        "uq_demographics_app_borrower",
+        "demographics",
+        ["application_id", "borrower_id"],
+        schema="hmda",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_demographics_app_borrower",
+        "demographics",
+        schema="hmda",
+    )
+    op.drop_index(
+        "ix_demographics_borrower_id",
+        table_name="demographics",
+        schema="hmda",
+    )
+    op.drop_column("demographics", "updated_at", schema="hmda")
+    op.drop_column("demographics", "borrower_id", schema="hmda")

--- a/packages/db/alembic/versions/f6a7b8c9d0e1_add_co_borrower_support.py
+++ b/packages/db/alembic/versions/f6a7b8c9d0e1_add_co_borrower_support.py
@@ -1,0 +1,88 @@
+# This project was developed with assistance from AI tools.
+"""add co-borrower support
+
+Create application_borrowers junction table, add borrower_id to documents,
+drop borrower_id from applications.
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-02-25 14:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f6a7b8c9d0e1"
+down_revision = "e5f6a7b8c9d0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Create application_borrowers junction table
+    op.create_table(
+        "application_borrowers",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "application_id",
+            sa.Integer,
+            sa.ForeignKey("applications.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "borrower_id",
+            sa.Integer,
+            sa.ForeignKey("borrowers.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("is_primary", sa.Boolean, nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("application_id", "borrower_id", name="uq_app_borrower"),
+    )
+
+    # 2. Add borrower_id to documents (nullable, for linking docs to specific borrowers)
+    op.add_column(
+        "documents",
+        sa.Column(
+            "borrower_id",
+            sa.Integer,
+            sa.ForeignKey("borrowers.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+    )
+
+    # 3. Drop borrower_id from applications
+    op.drop_constraint("applications_borrower_id_fkey", "applications", type_="foreignkey")
+    op.drop_index("ix_applications_borrower_id", table_name="applications")
+    op.drop_column("applications", "borrower_id")
+
+
+def downgrade() -> None:
+    # Re-add borrower_id to applications
+    op.add_column(
+        "applications",
+        sa.Column(
+            "borrower_id",
+            sa.Integer,
+            sa.ForeignKey("borrowers.id", ondelete="CASCADE"),
+            nullable=True,
+            index=True,
+        ),
+    )
+    op.create_index("ix_applications_borrower_id", "applications", ["borrower_id"])
+
+    # Drop borrower_id from documents
+    op.drop_column("documents", "borrower_id")
+
+    # Drop junction table
+    op.drop_table("application_borrowers")

--- a/packages/db/src/db/__init__.py
+++ b/packages/db/src/db/__init__.py
@@ -21,6 +21,7 @@ from .enums import (
 )
 from .models import (
     Application,
+    ApplicationBorrower,
     ApplicationFinancials,
     AuditEvent,
     Borrower,
@@ -53,6 +54,7 @@ __all__ = [
     "DecisionType",
     # Models
     "Application",
+    "ApplicationBorrower",
     "ApplicationFinancials",
     "AuditEvent",
     "Borrower",


### PR DESCRIPTION
## Summary

- **Co-borrower support** via `ApplicationBorrower` junction table -- drops `Application.borrower_id` FK, replaces with many-to-many relationship. API returns `borrowers: list[BorrowerSummary]` with `is_primary` flag. Data scope, document upload, PII masking, seed data all updated.
- **HMDA demographics upsert** with per-borrower tracking and conflict detection. Adds `borrower_id` + `updated_at` to `hmda.demographics` with unique constraint on `(application_id, borrower_id)`. Method precedence: `self_reported` overwrites `document_extraction`, not vice versa. Field-level conflicts tracked in audit trail.
- **Review fixes**: migration revision ID collision, image extraction prompt divergence, `HmdaLoanData.snapshot_at` onupdate, `create_application` MissingGreenlet regression fix.

## Test plan

- [x] 245 unit/integration tests passing (18 new)
- [x] Ruff lint clean
- [x] HMDA isolation check passing
- [x] Live-tested against real postgres + minio (12/12 scenarios passing):
  - Application list, co-borrower visibility, CRUD cycle
  - HMDA self-reported collection, upsert conflict detection, explicit borrower_id
  - Document upload with borrower_id resolution
  - Admin panel, health check, schema verification, junction table verification

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>