### PR TITLE
chore(api): harden security defaults and HMDA access controls

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -88,7 +88,7 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://user:password@summit-cap-db:5432/summit-cap
       COMPLIANCE_DATABASE_URL: postgresql+asyncpg://compliance_app:compliance_pass@summit-cap-db:5432/summit-cap
-      AUTH_DISABLED: "true"
+      AUTH_DISABLED: "${AUTH_DISABLED:-true}"
       KEYCLOAK_URL: http://keycloak:8080
       LLM_BASE_URL: "${LLM_BASE_URL:-http://host.docker.internal:1234/v1}"
       LLM_API_KEY: "${LLM_API_KEY:-not-needed}"

--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     )
     KEYCLOAK_URL: str = "http://localhost:8080"
     KEYCLOAK_REALM: str = "summit-cap"
+    KEYCLOAK_CLIENT_ID: str = "summit-cap-ui"
     JWKS_CACHE_TTL: int = Field(
         default=300,
         description="JWKS cache lifetime in seconds (default 5 minutes).",

--- a/packages/api/src/main.py
+++ b/packages/api/src/main.py
@@ -42,8 +42,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.ALLOWED_HOSTS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Include routers

--- a/packages/api/src/middleware/auth.py
+++ b/packages/api/src/middleware/auth.py
@@ -102,7 +102,8 @@ def _decode_token(token: str) -> TokenPayload:
         signing_key.key,
         algorithms=["RS256"],
         issuer=issuer,
-        options={"verify_aud": False},
+        audience=settings.KEYCLOAK_CLIENT_ID,
+        options={"verify_aud": True},
     )
     return TokenPayload(**payload)
 


### PR DESCRIPTION
## Summary
- **D3:** Make `AUTH_DISABLED` configurable via env override in compose.yml (`${AUTH_DISABLED:-true}`)
- **D5:** Replace CORS wildcard methods/headers with explicit allow-lists
- **D8:** Enable JWT audience validation against `KEYCLOAK_CLIENT_ID` setting
- **D9:** Scope HMDA application existence check through `apply_data_scope` (borrower can't submit HMDA for another borrower's app)
- **D19:** Validate `borrower_id` belongs to application via junction table before HMDA collection

## Test plan
- [x] 3 new tests: ownership block, admin bypass, invalid borrower_id rejection
- [x] All 248 existing tests pass
- [x] Ruff lint clean
- [x] HMDA isolation lint passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>