### PR TITLE
chore(api,db): audit JSONB and per-field HMDA collection methods

### DIFF
--- a/packages/api/src/schemas/admin.py
+++ b/packages/api/src/schemas/admin.py
@@ -13,7 +13,7 @@ class AuditEventItem(BaseModel):
     user_id: str | None = None
     user_role: str | None = None
     application_id: int | None = None
-    event_data: str | None = None
+    event_data: dict | str | None = None
 
 
 class AuditEventsResponse(BaseModel):

--- a/packages/api/src/schemas/hmda.py
+++ b/packages/api/src/schemas/hmda.py
@@ -18,6 +18,7 @@ class HmdaCollectionRequest(BaseModel):
     race_collected_method: str = Field(default="self_reported")
     ethnicity_collected_method: str = Field(default="self_reported")
     sex_collected_method: str = Field(default="self_reported")
+    age_collected_method: str = Field(default="self_reported")
 
 
 class HmdaCollectionResponse(BaseModel):

--- a/packages/api/src/services/audit.py
+++ b/packages/api/src/services/audit.py
@@ -7,7 +7,6 @@ is written here, enabling cross-lookup between developer-facing traces
 and compliance-facing audit logs.
 """
 
-import json
 import logging
 
 from db import AuditEvent
@@ -47,7 +46,7 @@ async def write_audit_event(
         user_id=user_id,
         user_role=user_role,
         application_id=application_id,
-        event_data=json.dumps(event_data) if event_data else None,
+        event_data=event_data,
     )
     session.add(audit)
     await session.flush()

--- a/packages/api/src/services/compliance/seed_hmda.py
+++ b/packages/api/src/services/compliance/seed_hmda.py
@@ -38,6 +38,7 @@ async def seed_hmda_demographics(
     """
     count = 0
     for demo_data in application_demographics:
+        method = demo_data.get("collection_method", "self_reported")
         demographic = HmdaDemographic(
             application_id=demo_data["application_id"],
             borrower_id=demo_data.get("borrower_id"),
@@ -45,7 +46,10 @@ async def seed_hmda_demographics(
             ethnicity=demo_data["ethnicity"],
             sex=demo_data["sex"],
             age=demo_data.get("age"),
-            collection_method=demo_data["collection_method"],
+            race_method=method,
+            ethnicity_method=method,
+            sex_method=method,
+            age_method=method,
         )
         compliance_session.add(demographic)
         count += 1

--- a/packages/api/tests/test_audit.py
+++ b/packages/api/tests/test_audit.py
@@ -70,7 +70,7 @@ async def test_write_audit_event_creates_row():
     assert added_obj.session_id == "sess-abc-123"
     assert added_obj.user_id == "test-user"
     assert added_obj.user_role == "prospect"
-    assert '"tool_name": "product_info"' in added_obj.event_data
+    assert added_obj.event_data["tool_name"] == "product_info"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/test_extraction.py
+++ b/packages/api/tests/test_extraction.py
@@ -530,7 +530,7 @@ class TestHmdaRouting:
         hmda_call = mock_compliance_session.add.call_args_list[0]
         hmda_obj = hmda_call[0][0]
         assert hmda_obj.application_id == 101
-        assert hmda_obj.collection_method == "document_extraction"
+        assert hmda_obj.race_method == "document_extraction"
         assert hmda_obj.race == "Asian"
         assert hmda_obj.sex == "Male"
         assert hmda_obj.age == "35"
@@ -561,13 +561,13 @@ class TestHmdaRouting:
         audit_obj = audit_call[0][0]
         assert audit_obj.event_type == "hmda_document_extraction"
         assert audit_obj.application_id == 101
-        event_data = json.loads(audit_obj.event_data)
-        assert event_data["document_id"] == 1
-        assert event_data["excluded_fields"][0]["field_name"] == "race"
-        assert event_data["detection_method"] == "keyword_match"
-        assert event_data["routed_to"] == "hmda.demographics"
-        assert "borrower_id" in event_data
-        assert "conflicts" in event_data
+        assert isinstance(audit_obj.event_data, dict)
+        assert audit_obj.event_data["document_id"] == 1
+        assert audit_obj.event_data["excluded_fields"][0]["field_name"] == "race"
+        assert audit_obj.event_data["detection_method"] == "keyword_match"
+        assert audit_obj.event_data["routed_to"] == "hmda.demographics"
+        assert "borrower_id" in audit_obj.event_data
+        assert "conflicts" in audit_obj.event_data
 
     @pytest.mark.asyncio
     async def test_extraction_passes_null_borrower_id(self):
@@ -598,8 +598,8 @@ class TestHmdaRouting:
         # Audit event also records borrower_id=None
         audit_call = mock_compliance_session.add.call_args_list[1]
         audit_obj = audit_call[0][0]
-        event_data = json.loads(audit_obj.event_data)
-        assert event_data["borrower_id"] is None
+        assert isinstance(audit_obj.event_data, dict)
+        assert audit_obj.event_data["borrower_id"] is None
 
     @pytest.mark.asyncio
     async def test_extraction_passes_borrower_id(self):
@@ -630,8 +630,8 @@ class TestHmdaRouting:
         # Audit event also includes borrower_id
         audit_call = mock_compliance_session.add.call_args_list[1]
         audit_obj = audit_call[0][0]
-        event_data = json.loads(audit_obj.event_data)
-        assert event_data["borrower_id"] == 42
+        assert isinstance(audit_obj.event_data, dict)
+        assert audit_obj.event_data["borrower_id"] == 42
 
 
 # ---------------------------------------------------------------------------

--- a/packages/db/alembic/versions/c4d5e6f7a8b9_audit_jsonb_and_per_field_methods.py
+++ b/packages/db/alembic/versions/c4d5e6f7a8b9_audit_jsonb_and_per_field_methods.py
@@ -1,0 +1,96 @@
+# This project was developed with assistance from AI tools.
+"""audit_events JSONB + per-field collection methods
+
+- D10: audit_events.event_data Text -> JSONB (both public + hmda schemas)
+- D15: hmda.demographics: replace collection_method with per-field method columns
+
+Revision ID: c4d5e6f7a8b9
+Revises: b3c4d5e6f7a8
+Create Date: 2026-02-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c4d5e6f7a8b9"
+down_revision = "b3c4d5e6f7a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # D10: audit_events.event_data Text -> JSONB (public schema)
+    op.execute(
+        "ALTER TABLE audit_events "
+        "ALTER COLUMN event_data TYPE JSONB USING event_data::jsonb"
+    )
+
+    # D10: audit_events.event_data Text -> JSONB (hmda schema)
+    op.execute(
+        "ALTER TABLE hmda.audit_events "
+        "ALTER COLUMN event_data TYPE JSONB USING event_data::jsonb"
+    )
+
+    # D15: Add per-field method columns to hmda.demographics
+    op.add_column(
+        "demographics",
+        sa.Column("race_method", sa.String(50), nullable=True),
+        schema="hmda",
+    )
+    op.add_column(
+        "demographics",
+        sa.Column("ethnicity_method", sa.String(50), nullable=True),
+        schema="hmda",
+    )
+    op.add_column(
+        "demographics",
+        sa.Column("sex_method", sa.String(50), nullable=True),
+        schema="hmda",
+    )
+    op.add_column(
+        "demographics",
+        sa.Column("age_method", sa.String(50), nullable=True),
+        schema="hmda",
+    )
+
+    # Migrate existing collection_method to all per-field columns
+    op.execute(
+        "UPDATE hmda.demographics SET "
+        "race_method = collection_method, "
+        "ethnicity_method = collection_method, "
+        "sex_method = collection_method, "
+        "age_method = collection_method"
+    )
+
+    # Drop the old single collection_method column
+    op.drop_column("demographics", "collection_method", schema="hmda")
+
+
+def downgrade() -> None:
+    # Restore single collection_method column
+    op.add_column(
+        "demographics",
+        sa.Column("collection_method", sa.String(50), nullable=False, server_default="self_reported"),
+        schema="hmda",
+    )
+
+    # Copy race_method back as the single method (best approximation)
+    op.execute(
+        "UPDATE hmda.demographics SET collection_method = COALESCE(race_method, 'self_reported')"
+    )
+
+    # Drop per-field method columns
+    op.drop_column("demographics", "age_method", schema="hmda")
+    op.drop_column("demographics", "sex_method", schema="hmda")
+    op.drop_column("demographics", "ethnicity_method", schema="hmda")
+    op.drop_column("demographics", "race_method", schema="hmda")
+
+    # D10: Revert JSONB -> Text
+    op.execute(
+        "ALTER TABLE hmda.audit_events "
+        "ALTER COLUMN event_data TYPE TEXT USING event_data::text"
+    )
+    op.execute(
+        "ALTER TABLE audit_events "
+        "ALTER COLUMN event_data TYPE TEXT USING event_data::text"
+    )

--- a/packages/db/src/db/models.py
+++ b/packages/db/src/db/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Float,
     ForeignKey,
     Integer,
+    JSON,
     Numeric,
     String,
     Text,
@@ -300,7 +301,7 @@ class AuditEvent(Base):
     event_type = Column(String(100), nullable=False, index=True)
     application_id = Column(Integer, nullable=True, index=True)
     decision_id = Column(Integer, nullable=True)
-    event_data = Column(Text, nullable=True)
+    event_data = Column(JSON, nullable=True)
     session_id = Column(String(255), nullable=True)
 
     def __repr__(self):
@@ -337,7 +338,10 @@ class HmdaDemographic(Base):
     ethnicity = Column(String(100), nullable=True)
     sex = Column(String(50), nullable=True)
     age = Column(String(20), nullable=True)
-    collection_method = Column(String(50), nullable=False, default="self_reported")
+    race_method = Column(String(50), nullable=True)
+    ethnicity_method = Column(String(50), nullable=True)
+    sex_method = Column(String(50), nullable=True)
+    age_method = Column(String(50), nullable=True)
     collected_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(


### PR DESCRIPTION
## Summary
- **D10:** `audit_events.event_data` migrated from `Text` to `JSONB` (both public and hmda schemas) -- eliminates json.dumps/loads overhead and enables native JSONB queries
- **D15:** Replaced single `collection_method` on `hmda.demographics` with per-field columns (`race_method`, `ethnicity_method`, `sex_method`, `age_method`) -- enables independent method tracking when race is self-reported but ethnicity comes from document extraction
- Updated all audit event writers (hmda.py, audit.py) to pass dicts directly
- Added `age_collected_method` to `HmdaCollectionRequest` schema
- Seed data maps existing `collection_method` to all per-field columns

## Test plan
- [x] 3 new tests: per-field methods stored, mixed-method upsert precedence, audit event_data is dict
- [x] All 251 tests pass (updated json.loads assertions to dict access)
- [x] Ruff lint clean
- [x] HMDA isolation lint passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>