### PR TITLE
chore(api,db): unify DB config, co-borrower endpoints, per-borrower financials

### DIFF
--- a/packages/api/src/schemas/application.py
+++ b/packages/api/src/schemas/application.py
@@ -64,3 +64,10 @@ class ApplicationListResponse(BaseModel):
 
     data: list[ApplicationResponse]
     count: int
+
+
+class AddBorrowerRequest(BaseModel):
+    """Add a borrower to an application."""
+
+    borrower_id: int
+    is_primary: bool = False

--- a/packages/api/uv.lock
+++ b/packages/api/uv.lock
@@ -2048,6 +2048,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "psycopg2-binary" },
+    { name = "pydantic-settings" },
     { name = "sqlalchemy" },
 ]
 
@@ -2056,6 +2057,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },

--- a/packages/db/alembic/versions/d5e6f7a8b9c0_per_borrower_financials.py
+++ b/packages/db/alembic/versions/d5e6f7a8b9c0_per_borrower_financials.py
@@ -1,0 +1,67 @@
+# This project was developed with assistance from AI tools.
+"""per-borrower financials
+
+D21: Add borrower_id to application_financials for per-borrower tracking.
+Drop unique constraint on application_id, replace with composite unique.
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-02-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d5e6f7a8b9c0"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add borrower_id column
+    op.add_column(
+        "application_financials",
+        sa.Column(
+            "borrower_id",
+            sa.Integer(),
+            sa.ForeignKey("borrowers.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_application_financials_borrower_id",
+        "application_financials",
+        ["borrower_id"],
+    )
+
+    # Drop the single-column unique constraint on application_id
+    op.drop_constraint(
+        "application_financials_application_id_key",
+        "application_financials",
+        type_="unique",
+    )
+
+    # Add composite unique constraint (application_id, borrower_id)
+    op.create_unique_constraint(
+        "uq_app_financials_app_borrower",
+        "application_financials",
+        ["application_id", "borrower_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_app_financials_app_borrower",
+        "application_financials",
+        type_="unique",
+    )
+    op.drop_index("ix_application_financials_borrower_id", "application_financials")
+    op.drop_column("application_financials", "borrower_id")
+
+    # Restore single unique constraint on application_id
+    op.create_unique_constraint(
+        "application_financials_application_id_key",
+        "application_financials",
+        ["application_id"],
+    )

--- a/packages/db/pyproject.toml
+++ b/packages/db/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "alembic>=1.13.0",
     "asyncpg>=0.29.0",
     "psycopg2-binary>=2.9.0",
+    "pydantic-settings>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/db/src/db/config.py
+++ b/packages/db/src/db/config.py
@@ -1,0 +1,22 @@
+# This project was developed with assistance from AI tools.
+"""Database configuration via pydantic-settings.
+
+Replaces os.environ.get() calls in database.py with a typed settings class.
+"""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DatabaseSettings(BaseSettings):
+    """Database connection settings -- reads from environment variables."""
+
+    model_config = SettingsConfigDict(extra="ignore")
+
+    DATABASE_URL: str = "postgresql+asyncpg://user:password@localhost:5433/summit-cap"
+    COMPLIANCE_DATABASE_URL: str = (
+        "postgresql+asyncpg://compliance_app:compliance_pass@localhost:5433/summit-cap"
+    )
+    SQL_ECHO: bool = False
+
+
+db_settings = DatabaseSettings()

--- a/packages/db/src/db/database.py
+++ b/packages/db/src/db/database.py
@@ -4,7 +4,6 @@ Database configuration and utilities
 """
 
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any
 
@@ -12,22 +11,12 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL",
-    "postgresql+asyncpg://user:password@localhost:5433/summit-cap",
-)
+from .config import db_settings
 
-COMPLIANCE_DATABASE_URL = os.environ.get(
-    "COMPLIANCE_DATABASE_URL",
-    "postgresql+asyncpg://compliance_app:compliance_pass@localhost:5433/summit-cap",
-)
-
-_SQL_ECHO = os.environ.get("SQL_ECHO", "false").lower() == "true"
-
-engine = create_async_engine(DATABASE_URL, echo=_SQL_ECHO)
+engine = create_async_engine(db_settings.DATABASE_URL, echo=db_settings.SQL_ECHO)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, class_=AsyncSession)
 
-compliance_engine = create_async_engine(COMPLIANCE_DATABASE_URL, echo=_SQL_ECHO)
+compliance_engine = create_async_engine(db_settings.COMPLIANCE_DATABASE_URL, echo=db_settings.SQL_ECHO)
 ComplianceSessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=compliance_engine, class_=AsyncSession,
 )

--- a/packages/db/src/db/models.py
+++ b/packages/db/src/db/models.py
@@ -133,14 +133,21 @@ class ApplicationBorrower(Base):
 
 
 class ApplicationFinancials(Base):
-    """Financial details for an application."""
+    """Financial details for an application, optionally per-borrower."""
 
     __tablename__ = "application_financials"
+    __table_args__ = (
+        UniqueConstraint("application_id", "borrower_id", name="uq_app_financials_app_borrower"),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     application_id = Column(
         Integer, ForeignKey("applications.id", ondelete="CASCADE"),
-        nullable=False, unique=True, index=True,
+        nullable=False, index=True,
+    )
+    borrower_id = Column(
+        Integer, ForeignKey("borrowers.id", ondelete="SET NULL"),
+        nullable=True, index=True,
     )
     gross_monthly_income = Column(Numeric(12, 2), nullable=True)
     monthly_debts = Column(Numeric(12, 2), nullable=True)


### PR DESCRIPTION
## Summary
- **D18:** Replace os.environ.get() in db/database.py with pydantic-settings DatabaseSettings class (db/config.py), adding pydantic-settings as a db package dependency
- **D20:** Add POST/DELETE /applications/{id}/borrowers endpoints for co-borrower management -- restricted to loan_officer, underwriter, and admin roles. Validates borrower existence, prevents duplicates, enforces at-least-one-borrower and primary-borrower rules
- **D21:** Add borrower_id FK to ApplicationFinancials with composite unique constraint (application_id, borrower_id) for per-borrower financial tracking. No new CRUD endpoints yet -- data model ready for Phase 3 loan officer pipeline

## Test plan
- [x] 4 new tests: add borrower, remove borrower, cannot remove last borrower, borrower role gets 403
- [x] All 255 tests pass
- [x] Ruff lint clean
- [x] HMDA isolation lint passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>