### PR TITLE
feat(api): document freshness check in extraction pipeline

### DIFF
--- a/packages/api/src/services/extraction.py
+++ b/packages/api/src/services/extraction.py
@@ -28,6 +28,7 @@ from .extraction_prompts import (
     build_extraction_prompt,
     build_image_extraction_prompt,
 )
+from .freshness import check_freshness
 from .storage import get_storage_service
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,11 @@ class ExtractionService:
                         demographic_extractions,
                         borrower_id=doc.borrower_id,
                     )
+
+                # Document freshness check
+                freshness_flag = check_freshness(doc_type, lending_extractions)
+                if freshness_flag:
+                    quality_flags.append(freshness_flag)
 
                 # Store quality flags
                 doc.quality_flags = json.dumps(quality_flags) if quality_flags else None

--- a/packages/api/src/services/extraction_prompts.py
+++ b/packages/api/src/services/extraction_prompts.py
@@ -50,6 +50,7 @@ QUALITY_FLAGS = [
     "blurry",
     "incomplete",
     "wrong_period",
+    "future_date",
     "document_type_mismatch",
     "unsigned",
 ]

--- a/packages/api/src/services/freshness.py
+++ b/packages/api/src/services/freshness.py
@@ -1,0 +1,95 @@
+# This project was developed with assistance from AI tools.
+"""Document freshness validation.
+
+Pure function that checks whether extracted date fields fall within
+acceptable recency thresholds for each document type. Stale or future-dated
+documents get a quality flag that surfaces in the completeness response.
+"""
+
+import logging
+from datetime import date, timedelta
+
+logger = logging.getLogger(__name__)
+
+# Map doc_type -> (date field name to check, max age in days)
+# Only doc types with time-sensitive date fields are listed.
+_FRESHNESS_THRESHOLDS: dict[str, tuple[str, int]] = {
+    "pay_stub": ("pay_period_end", 30),
+    "bank_statement": ("statement_period_end", 60),
+}
+
+# Date formats to try when parsing extracted date strings
+_DATE_FORMATS = [
+    "%Y-%m-%d",  # 2026-01-15
+    "%m/%d/%Y",  # 01/15/2026
+    "%m-%d-%Y",  # 01-15-2026
+    "%Y/%m/%d",  # 2026/01/15
+    "%d/%m/%Y",  # 15/01/2026
+    "%B %d, %Y",  # January 15, 2026
+    "%b %d, %Y",  # Jan 15, 2026
+]
+
+
+def _parse_date(value: str) -> date | None:
+    """Try multiple date formats to parse a string into a date."""
+    from datetime import datetime
+
+    for fmt in _DATE_FORMATS:
+        try:
+            return datetime.strptime(value.strip(), fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def check_freshness(
+    doc_type: str,
+    extractions: list[dict],
+    reference_date: date | None = None,
+) -> str | None:
+    """Check if a document's date fields are within freshness thresholds.
+
+    Args:
+        doc_type: The document type (e.g. "pay_stub", "bank_statement").
+        extractions: List of extraction dicts with field_name/field_value.
+        reference_date: Date to compare against (defaults to today).
+
+    Returns:
+        "wrong_period" if the document is stale, "future_date" if the date
+        is in the future, or None if fresh / no threshold applies.
+    """
+    threshold = _FRESHNESS_THRESHOLDS.get(doc_type)
+    if threshold is None:
+        return None
+
+    field_name, max_days = threshold
+    ref = reference_date or date.today()
+
+    # Find the date field in extractions
+    date_value = None
+    for ext in extractions:
+        if ext.get("field_name", "").lower() == field_name:
+            date_value = ext.get("field_value")
+            break
+
+    if date_value is None:
+        return None
+
+    parsed = _parse_date(str(date_value))
+    if parsed is None:
+        logger.warning(
+            "Could not parse date '%s' from field '%s' on %s",
+            date_value,
+            field_name,
+            doc_type,
+        )
+        return None
+
+    if parsed > ref:
+        return "future_date"
+
+    age = ref - parsed
+    if age > timedelta(days=max_days):
+        return "wrong_period"
+
+    return None

--- a/packages/api/tests/test_freshness.py
+++ b/packages/api/tests/test_freshness.py
@@ -1,0 +1,83 @@
+# This project was developed with assistance from AI tools.
+"""Tests for document freshness validation."""
+
+from datetime import date
+
+from src.services.freshness import check_freshness
+
+
+def test_pay_stub_fresh():
+    """Pay stub within 30 days is fresh."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "2026-02-01"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_pay_stub_stale():
+    """Pay stub older than 30 days gets wrong_period."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "2026-01-01"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result == "wrong_period"
+
+
+def test_pay_stub_future_date():
+    """Pay stub with future date gets future_date flag."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "2026-03-15"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result == "future_date"
+
+
+def test_bank_statement_fresh():
+    """Bank statement within 60 days is fresh."""
+    extractions = [{"field_name": "statement_period_end", "field_value": "2026-01-15"}]
+    result = check_freshness("bank_statement", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_bank_statement_stale():
+    """Bank statement older than 60 days gets wrong_period."""
+    extractions = [{"field_name": "statement_period_end", "field_value": "2025-11-01"}]
+    result = check_freshness("bank_statement", extractions, reference_date=date(2026, 2, 20))
+    assert result == "wrong_period"
+
+
+def test_no_threshold_for_w2():
+    """W2 has no freshness threshold -- always returns None."""
+    extractions = [{"field_name": "tax_year", "field_value": "2020"}]
+    result = check_freshness("w2", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_missing_date_field():
+    """Missing date field returns None (can't determine freshness)."""
+    extractions = [{"field_name": "gross_pay", "field_value": "5000"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_unparseable_date():
+    """Unparseable date value returns None."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "not-a-date"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_slash_date_format():
+    """Handles MM/DD/YYYY date format."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "02/10/2026"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_boundary_exactly_30_days():
+    """Exactly 30 days old is still fresh (not stale)."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "2026-01-21"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result is None
+
+
+def test_boundary_31_days():
+    """31 days old is stale."""
+    extractions = [{"field_name": "pay_period_end", "field_value": "2026-01-20"}]
+    result = check_freshness("pay_stub", extractions, reference_date=date(2026, 2, 20))
+    assert result == "wrong_period"


### PR DESCRIPTION
## Summary
- Add `check_freshness()` pure function that validates extracted date fields against recency thresholds (pay_stub: 30d, bank_statement: 60d)
- Integrated into extraction pipeline after HMDA filter -- stale docs get `wrong_period` flag, future-dated docs get `future_date` flag
- Both flags surface automatically in the completeness endpoint response from PR #32

## Stories
- S-2-F6-03: Document freshness warnings

## Test plan
- [x] 11 unit tests: fresh, stale, future, boundary (30d/31d), missing field, unparseable date, multiple date formats
- [x] 368 total tests passing, lint clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>