### PR TITLE
feat(api): rate lock status endpoint + agent tool

### DIFF
--- a/config/agents/borrower-assistant.yaml
+++ b/config/agents/borrower-assistant.yaml
@@ -17,6 +17,7 @@ system_prompt: |
   - Look up applicable regulatory deadlines using the regulatory_deadlines tool
   - Present required disclosures and record acknowledgments using the acknowledge_disclosure tool
   - Check which disclosures have been acknowledged using the disclosure_status tool
+  - Check rate lock status using the rate_lock_status tool
   - Explain mortgage concepts, application steps, and required documents
 
   PROACTIVE DOCUMENT GUIDANCE:
@@ -36,6 +37,13 @@ system_prompt: |
   - If the borrower refuses or wants more time, respect their decision and note
     it without pressuring them. Do not re-ask in this session.
   - Each disclosure requires a separate acknowledgment -- do not batch them.
+
+  RATE LOCK AWARENESS:
+  - When the borrower asks about their rate lock, interest rate, or closing timeline,
+    use the rate_lock_status tool to check current status.
+  - If the rate lock is expiring within 7 days, proactively mention it when the
+    borrower asks about application status or timelines.
+  - For urgent expirations (3 days or less), emphasize the urgency clearly.
 
   REGULATORY DEADLINE AWARENESS:
   - When the borrower asks about timeline, status, or deadlines, check for
@@ -70,6 +78,9 @@ tools:
     allowed_roles: [borrower, loan_officer, admin]
   - name: disclosure_status
     description: "Check which required disclosures have been acknowledged and which are pending"
+    allowed_roles: [borrower, loan_officer, underwriter, ceo, admin]
+  - name: rate_lock_status
+    description: "Check rate lock status including locked rate, expiration, and days remaining"
     allowed_roles: [borrower, loan_officer, underwriter, ceo, admin]
 
 model_routing:

--- a/packages/api/src/agents/borrower_assistant.py
+++ b/packages/api/src/agents/borrower_assistant.py
@@ -3,7 +3,7 @@
 
 Tools: product_info, affordability_calc, document_completeness,
 application_status, regulatory_deadlines, acknowledge_disclosure,
-disclosure_status.
+disclosure_status, rate_lock_status.
 """
 
 import logging
@@ -18,6 +18,7 @@ from .borrower_tools import (
     application_status,
     disclosure_status,
     document_completeness,
+    rate_lock_status,
     regulatory_deadlines,
 )
 from .tools import affordability_calc, product_info
@@ -36,6 +37,7 @@ def build_graph(config: dict[str, Any], checkpointer=None):
         regulatory_deadlines,
         acknowledge_disclosure,
         disclosure_status,
+        rate_lock_status,
     ]
 
     tool_descriptions = "\n".join(f"- {t.name}: {t.description}" for t in tools)

--- a/packages/api/src/schemas/rate_lock.py
+++ b/packages/api/src/schemas/rate_lock.py
@@ -1,0 +1,16 @@
+# This project was developed with assistance from AI tools.
+"""Pydantic response models for rate lock endpoints."""
+
+from pydantic import BaseModel
+
+
+class RateLockResponse(BaseModel):
+    """Response for GET /api/applications/{id}/rate-lock."""
+
+    application_id: int
+    status: str  # "active", "expired", "none"
+    locked_rate: float | None = None
+    lock_date: str | None = None
+    expiration_date: str | None = None
+    days_remaining: int | None = None
+    is_urgent: bool | None = None

--- a/packages/api/src/services/rate_lock.py
+++ b/packages/api/src/services/rate_lock.py
@@ -1,0 +1,88 @@
+# This project was developed with assistance from AI tools.
+"""Rate lock status service.
+
+Queries the rate_locks table for an application and computes the
+current status (active, expired, none) with days remaining.
+"""
+
+from datetime import UTC, datetime
+
+from db import Application, ApplicationBorrower, RateLock
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ..schemas.auth import UserContext
+from ..services.scope import apply_data_scope
+
+
+async def get_rate_lock_status(
+    session: AsyncSession,
+    user: UserContext,
+    application_id: int,
+) -> dict | None:
+    """Return rate lock status for an application.
+
+    Applies data scope filtering so borrowers can only see their own
+    applications.  Returns None if the application is not found or
+    out of scope.
+
+    Returns:
+        Dict with rate lock info, or dict with status='none' if no lock exists,
+        or None if application not found / out of scope.
+    """
+    # Verify the application exists and is in scope
+    app_stmt = (
+        select(Application)
+        .options(
+            selectinload(Application.application_borrowers).joinedload(ApplicationBorrower.borrower)
+        )
+        .where(Application.id == application_id)
+    )
+    app_stmt = apply_data_scope(app_stmt, user.data_scope, user)
+    app_result = await session.execute(app_stmt)
+    app = app_result.unique().scalar_one_or_none()
+
+    if app is None:
+        return None
+
+    # Query the most recent active rate lock for this application
+    lock_stmt = (
+        select(RateLock)
+        .where(RateLock.application_id == application_id)
+        .order_by(RateLock.created_at.desc())
+        .limit(1)
+    )
+    lock_result = await session.execute(lock_stmt)
+    rate_lock = lock_result.scalar_one_or_none()
+
+    if rate_lock is None:
+        return {
+            "application_id": application_id,
+            "status": "none",
+        }
+
+    now = datetime.now(UTC)
+    expiration = rate_lock.expiration_date
+    # Ensure timezone-aware comparison
+    if expiration.tzinfo is None:
+        expiration = expiration.replace(tzinfo=UTC)
+
+    days_remaining = (expiration - now).days
+
+    if not rate_lock.is_active:
+        lock_status = "expired"
+    elif days_remaining < 0:
+        lock_status = "expired"
+    else:
+        lock_status = "active"
+
+    return {
+        "application_id": application_id,
+        "status": lock_status,
+        "locked_rate": rate_lock.locked_rate,
+        "lock_date": rate_lock.lock_date.isoformat(),
+        "expiration_date": rate_lock.expiration_date.isoformat(),
+        "days_remaining": max(days_remaining, 0),
+        "is_urgent": 0 < days_remaining <= 7,
+    }

--- a/packages/api/tests/test_rate_lock.py
+++ b/packages/api/tests/test_rate_lock.py
@@ -1,0 +1,313 @@
+# This project was developed with assistance from AI tools.
+"""Tests for rate lock status service, endpoint, and agent tool."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.borrower_tools import rate_lock_status
+from src.schemas.rate_lock import RateLockResponse
+from src.services.rate_lock import get_rate_lock_status
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _state(user_id="sarah-uuid", role="borrower"):
+    return {"user_id": user_id, "user_role": role}
+
+
+def _mock_rate_lock(
+    locked_rate=6.875,
+    lock_date=None,
+    expiration_date=None,
+    is_active=True,
+):
+    """Create a mock RateLock ORM object."""
+    rl = MagicMock()
+    rl.locked_rate = locked_rate
+    rl.lock_date = lock_date or datetime.now(UTC) - timedelta(days=10)
+    rl.expiration_date = expiration_date or datetime.now(UTC) + timedelta(days=35)
+    rl.is_active = is_active
+    rl.created_at = datetime.now(UTC)
+    return rl
+
+
+# ---------------------------------------------------------------------------
+# Service: get_rate_lock_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_returns_none_for_out_of_scope():
+    """No application found -> None."""
+    session = AsyncMock()
+    # Application query returns None
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = None
+    session.execute.return_value = app_result
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_service_returns_none_status_when_no_lock():
+    """Application exists but no rate lock."""
+    session = AsyncMock()
+
+    # First call: application found
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    # Second call: no rate lock
+    lock_result = MagicMock()
+    lock_result.scalar_one_or_none.return_value = None
+
+    session.execute.side_effect = [app_result, lock_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 1)
+    assert result["status"] == "none"
+    assert result["application_id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_service_returns_active_with_days_remaining():
+    """Active rate lock with days remaining."""
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    rl = _mock_rate_lock(
+        locked_rate=6.5,
+        expiration_date=datetime.now(UTC) + timedelta(days=20),
+    )
+    lock_result = MagicMock()
+    lock_result.scalar_one_or_none.return_value = rl
+
+    session.execute.side_effect = [app_result, lock_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 1)
+    assert result["status"] == "active"
+    assert result["locked_rate"] == 6.5
+    assert result["days_remaining"] >= 19
+    assert result["is_urgent"] is False
+
+
+@pytest.mark.asyncio
+async def test_service_marks_urgent_within_7_days():
+    """Rate lock expiring in 5 days should be urgent."""
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    rl = _mock_rate_lock(expiration_date=datetime.now(UTC) + timedelta(days=5))
+    lock_result = MagicMock()
+    lock_result.scalar_one_or_none.return_value = rl
+
+    session.execute.side_effect = [app_result, lock_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 1)
+    assert result["status"] == "active"
+    assert result["is_urgent"] is True
+
+
+@pytest.mark.asyncio
+async def test_service_returns_expired_when_past_expiration():
+    """Rate lock past expiration date should be expired."""
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    rl = _mock_rate_lock(
+        expiration_date=datetime.now(UTC) - timedelta(days=2),
+        is_active=True,  # DB still says active but date is past
+    )
+    lock_result = MagicMock()
+    lock_result.scalar_one_or_none.return_value = rl
+
+    session.execute.side_effect = [app_result, lock_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 1)
+    assert result["status"] == "expired"
+    assert result["days_remaining"] == 0
+
+
+@pytest.mark.asyncio
+async def test_service_returns_expired_when_is_active_false():
+    """Rate lock with is_active=False should be expired."""
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    rl = _mock_rate_lock(
+        expiration_date=datetime.now(UTC) + timedelta(days=10),
+        is_active=False,
+    )
+    lock_result = MagicMock()
+    lock_result.scalar_one_or_none.return_value = rl
+
+    session.execute.side_effect = [app_result, lock_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_rate_lock_status(session, user, 1)
+    assert result["status"] == "expired"
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_active():
+    resp = RateLockResponse(
+        application_id=1,
+        status="active",
+        locked_rate=6.5,
+        lock_date="2026-02-01T00:00:00+00:00",
+        expiration_date="2026-03-15T00:00:00+00:00",
+        days_remaining=20,
+        is_urgent=False,
+    )
+    assert resp.status == "active"
+    assert resp.locked_rate == 6.5
+
+
+def test_schema_none():
+    resp = RateLockResponse(application_id=1, status="none")
+    assert resp.locked_rate is None
+    assert resp.days_remaining is None
+
+
+# ---------------------------------------------------------------------------
+# Agent tool: rate_lock_status
+# ---------------------------------------------------------------------------
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_rate_lock_status")
+async def test_tool_active_lock(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "application_id": 1,
+        "status": "active",
+        "locked_rate": 6.875,
+        "lock_date": "2026-02-15T00:00:00+00:00",
+        "expiration_date": "2026-03-25T00:00:00+00:00",
+        "days_remaining": 25,
+        "is_urgent": False,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await rate_lock_status.ainvoke({"application_id": 1, "state": _state()})
+
+    assert "Active" in result
+    assert "6.875%" in result
+    assert "25" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_rate_lock_status")
+async def test_tool_no_lock(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "application_id": 1,
+        "status": "none",
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await rate_lock_status.ainvoke({"application_id": 1, "state": _state()})
+
+    assert "does not have a rate lock" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_rate_lock_status")
+async def test_tool_expired_lock(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "application_id": 1,
+        "status": "expired",
+        "locked_rate": 7.0,
+        "lock_date": "2026-01-01T00:00:00+00:00",
+        "expiration_date": "2026-02-01T00:00:00+00:00",
+        "days_remaining": 0,
+        "is_urgent": False,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await rate_lock_status.ainvoke({"application_id": 1, "state": _state()})
+
+    assert "Expired" in result
+    assert "expired" in result.lower()
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_rate_lock_status")
+async def test_tool_urgent_lock(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "application_id": 1,
+        "status": "active",
+        "locked_rate": 6.5,
+        "lock_date": "2026-02-01T00:00:00+00:00",
+        "expiration_date": "2026-02-28T00:00:00+00:00",
+        "days_remaining": 2,
+        "is_urgent": True,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await rate_lock_status.ainvoke({"application_id": 1, "state": _state()})
+
+    assert "Urgent" in result
+    assert "2 days" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_rate_lock_status")
+async def test_tool_not_found(mock_service, mock_session_cls):
+    mock_service.return_value = None
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await rate_lock_status.ainvoke({"application_id": 999, "state": _state()})
+
+    assert "not found" in result


### PR DESCRIPTION
## Summary
- Add `GET /applications/{id}/rate-lock` endpoint returning lock status, rate, dates, days remaining, and urgency flag
- Add `rate_lock_status` agent tool for the borrower assistant with tiered urgency alerts (0/3/7 day thresholds)
- Rate lock service enforces data-scope filtering so borrowers only see their own applications
- Covers stories S-2-F27-01 (borrower views rate lock status) and S-2-F27-03 (agent alerts on expiration)

## Test plan
- [x] 13 new tests (6 service, 2 schema, 5 tool) -- 335 total passing
- [x] Lint clean (ruff check + pre-commit hooks)
- [x] Live tested REST endpoint: active locks, no lock, 404 for nonexistent
- [x] Live tested service + tool as actual borrower: active, out-of-scope, expired scenarios
- [x] Live tested WebSocket agent: tool invoked correctly, data scope enforced

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>