### PR TITLE
feat(api,db): borrower condition response via chat (S-2-F28-01, F28-02)

### DIFF
--- a/config/agents/borrower-assistant.yaml
+++ b/config/agents/borrower-assistant.yaml
@@ -18,6 +18,7 @@ system_prompt: |
   - Present required disclosures and record acknowledgments using the acknowledge_disclosure tool
   - Check which disclosures have been acknowledged using the disclosure_status tool
   - Check rate lock status using the rate_lock_status tool
+  - List and respond to underwriting conditions using list_conditions and respond_to_condition_tool
   - Explain mortgage concepts, application steps, and required documents
 
   PROACTIVE DOCUMENT GUIDANCE:
@@ -37,6 +38,18 @@ system_prompt: |
   - If the borrower refuses or wants more time, respect their decision and note
     it without pressuring them. Do not re-ask in this session.
   - Each disclosure requires a separate acknowledgment -- do not batch them.
+
+  UNDERWRITING CONDITIONS:
+  - When the borrower has open conditions, proactively notify them at the start
+    of a conversation or when they ask about application status.
+  - Use list_conditions to retrieve pending conditions for the borrower's application.
+  - When the borrower provides a text explanation for a condition, use
+    respond_to_condition_tool to record it.
+  - If a condition requires a document upload rather than a text explanation,
+    tell the borrower to upload the document and clarify which condition it is for.
+  - After recording a response, remind the borrower of any remaining open conditions.
+  - Handle partial responses gracefully: if the borrower addresses one condition
+    but not another, acknowledge the completed one and prompt for the next.
 
   RATE LOCK AWARENESS:
   - When the borrower asks about their rate lock, interest rate, or closing timeline,
@@ -82,6 +95,12 @@ tools:
   - name: rate_lock_status
     description: "Check rate lock status including locked rate, expiration, and days remaining"
     allowed_roles: [borrower, loan_officer, underwriter, ceo, admin]
+  - name: list_conditions
+    description: "List open underwriting conditions for an application"
+    allowed_roles: [borrower, loan_officer, underwriter, admin]
+  - name: respond_to_condition_tool
+    description: "Record a borrower's text response to an underwriting condition"
+    allowed_roles: [borrower, admin]
 
 model_routing:
   strategy: per_query

--- a/packages/api/src/agents/borrower_assistant.py
+++ b/packages/api/src/agents/borrower_assistant.py
@@ -3,7 +3,8 @@
 
 Tools: product_info, affordability_calc, document_completeness,
 application_status, regulatory_deadlines, acknowledge_disclosure,
-disclosure_status, rate_lock_status.
+disclosure_status, rate_lock_status, list_conditions,
+respond_to_condition_tool.
 """
 
 import logging
@@ -18,8 +19,10 @@ from .borrower_tools import (
     application_status,
     disclosure_status,
     document_completeness,
+    list_conditions,
     rate_lock_status,
     regulatory_deadlines,
+    respond_to_condition_tool,
 )
 from .tools import affordability_calc, product_info
 
@@ -38,6 +41,8 @@ def build_graph(config: dict[str, Any], checkpointer=None):
         acknowledge_disclosure,
         disclosure_status,
         rate_lock_status,
+        list_conditions,
+        respond_to_condition_tool,
     ]
 
     tool_descriptions = "\n".join(f"- {t.name}: {t.description}" for t in tools)

--- a/packages/api/src/schemas/condition.py
+++ b/packages/api/src/schemas/condition.py
@@ -1,0 +1,29 @@
+# This project was developed with assistance from AI tools.
+"""Schemas for condition endpoints."""
+
+from pydantic import BaseModel
+
+
+class ConditionItem(BaseModel):
+    """Single condition in a list response."""
+
+    id: int
+    description: str
+    severity: str | None = None
+    status: str | None = None
+    response_text: str | None = None
+    issued_by: str | None = None
+    created_at: str | None = None
+
+
+class ConditionListResponse(BaseModel):
+    """Response for GET /applications/{id}/conditions."""
+
+    data: list[ConditionItem]
+    count: int
+
+
+class ConditionRespondRequest(BaseModel):
+    """Request body for responding to a condition with text."""
+
+    response_text: str

--- a/packages/api/src/services/condition.py
+++ b/packages/api/src/services/condition.py
@@ -1,0 +1,191 @@
+# This project was developed with assistance from AI tools.
+"""Condition service for borrower condition responses.
+
+Handles listing open conditions (with data scope), recording text
+responses, and linking uploaded documents to conditions.
+"""
+
+from db import (
+    Application,
+    ApplicationBorrower,
+    Condition,
+    ConditionStatus,
+    Document,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from ..schemas.auth import UserContext
+from ..services.scope import apply_data_scope
+
+
+async def get_conditions(
+    session: AsyncSession,
+    user: UserContext,
+    application_id: int,
+    *,
+    open_only: bool = False,
+) -> list[dict] | None:
+    """Return conditions for an application, respecting data scope.
+
+    Returns None if the application is not found or out of scope.
+    Returns a list of condition dicts otherwise (may be empty).
+    """
+    # Verify application exists and is in scope
+    app_stmt = (
+        select(Application)
+        .options(
+            selectinload(Application.application_borrowers).joinedload(ApplicationBorrower.borrower)
+        )
+        .where(Application.id == application_id)
+    )
+    app_stmt = apply_data_scope(app_stmt, user.data_scope, user)
+    app_result = await session.execute(app_stmt)
+    app = app_result.unique().scalar_one_or_none()
+
+    if app is None:
+        return None
+
+    # Query conditions for this application
+    cond_stmt = select(Condition).where(Condition.application_id == application_id)
+    if open_only:
+        cond_stmt = cond_stmt.where(
+            Condition.status.in_([ConditionStatus.OPEN, ConditionStatus.RESPONDED])
+        )
+    cond_stmt = cond_stmt.order_by(Condition.created_at)
+    cond_result = await session.execute(cond_stmt)
+    conditions = cond_result.scalars().all()
+
+    return [
+        {
+            "id": c.id,
+            "description": c.description,
+            "severity": c.severity.value if c.severity else None,
+            "status": c.status.value if c.status else None,
+            "response_text": c.response_text,
+            "issued_by": c.issued_by,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+        }
+        for c in conditions
+    ]
+
+
+async def respond_to_condition(
+    session: AsyncSession,
+    user: UserContext,
+    application_id: int,
+    condition_id: int,
+    response_text: str,
+) -> dict | None:
+    """Record a borrower's text response to a condition.
+
+    Returns the updated condition dict, or None if not found / out of scope.
+    Updates status to RESPONDED if currently OPEN.
+    """
+    # Verify application scope
+    app_stmt = (
+        select(Application)
+        .options(
+            selectinload(Application.application_borrowers).joinedload(ApplicationBorrower.borrower)
+        )
+        .where(Application.id == application_id)
+    )
+    app_stmt = apply_data_scope(app_stmt, user.data_scope, user)
+    app_result = await session.execute(app_stmt)
+    app = app_result.unique().scalar_one_or_none()
+
+    if app is None:
+        return None
+
+    # Fetch the condition
+    cond_stmt = select(Condition).where(
+        Condition.id == condition_id,
+        Condition.application_id == application_id,
+    )
+    cond_result = await session.execute(cond_stmt)
+    condition = cond_result.scalar_one_or_none()
+
+    if condition is None:
+        return None
+
+    # Record response
+    condition.response_text = response_text
+    if condition.status == ConditionStatus.OPEN:
+        condition.status = ConditionStatus.RESPONDED
+
+    await session.commit()
+    await session.refresh(condition)
+
+    return {
+        "id": condition.id,
+        "description": condition.description,
+        "status": condition.status.value,
+        "response_text": condition.response_text,
+    }
+
+
+async def link_document_to_condition(
+    session: AsyncSession,
+    user: UserContext,
+    application_id: int,
+    condition_id: int,
+    document_id: int,
+) -> dict | None:
+    """Link a document to a condition and update status to RESPONDED.
+
+    Returns the updated condition dict, or None if not found / out of scope.
+    """
+    # Verify application scope
+    app_stmt = (
+        select(Application)
+        .options(
+            selectinload(Application.application_borrowers).joinedload(ApplicationBorrower.borrower)
+        )
+        .where(Application.id == application_id)
+    )
+    app_stmt = apply_data_scope(app_stmt, user.data_scope, user)
+    app_result = await session.execute(app_stmt)
+    app = app_result.unique().scalar_one_or_none()
+
+    if app is None:
+        return None
+
+    # Fetch condition
+    cond_stmt = select(Condition).where(
+        Condition.id == condition_id,
+        Condition.application_id == application_id,
+    )
+    cond_result = await session.execute(cond_stmt)
+    condition = cond_result.scalar_one_or_none()
+
+    if condition is None:
+        return None
+
+    # Fetch document (must belong to the same application)
+    doc_stmt = select(Document).where(
+        Document.id == document_id,
+        Document.application_id == application_id,
+    )
+    doc_result = await session.execute(doc_stmt)
+    document = doc_result.scalar_one_or_none()
+
+    if document is None:
+        return None
+
+    # Link document to condition
+    document.condition_id = condition_id
+
+    # Update condition status if OPEN
+    if condition.status == ConditionStatus.OPEN:
+        condition.status = ConditionStatus.RESPONDED
+
+    await session.commit()
+    await session.refresh(condition)
+
+    return {
+        "id": condition.id,
+        "description": condition.description,
+        "status": condition.status.value,
+        "document_id": document_id,
+    }

--- a/packages/api/tests/functional/test_condition_flow.py
+++ b/packages/api/tests/functional/test_condition_flow.py
@@ -1,0 +1,196 @@
+# This project was developed with assistance from AI tools.
+"""Functional tests: Condition listing and response endpoints across personas.
+
+Validates that condition endpoints respect data scope (borrowers see own,
+LO sees assigned, prospect blocked) and return correct response shapes
+through the real FastAPI app with mocked DB.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from db.enums import ConditionSeverity, ConditionStatus
+
+from .data_factory import make_app_sarah_1
+from .personas import borrower_sarah, loan_officer, prospect, underwriter
+
+pytestmark = pytest.mark.functional
+
+
+def _mock_condition(
+    id=1,
+    description="Verify employment",
+    severity=ConditionSeverity.PRIOR_TO_APPROVAL,
+    status=ConditionStatus.OPEN,
+    response_text=None,
+    issued_by="maria-uuid",
+):
+    c = MagicMock()
+    c.id = id
+    c.description = description
+    c.severity = severity
+    c.status = status
+    c.response_text = response_text
+    c.issued_by = issued_by
+    c.created_at = MagicMock()
+    c.created_at.isoformat.return_value = "2026-02-20T00:00:00+00:00"
+    return c
+
+
+def _make_conditions_session(application, conditions):
+    """Build a mock session for the conditions list endpoint.
+
+    The conditions service runs two queries:
+      1. Application lookup (with data scope) -> unique().scalar_one_or_none()
+      2. Condition query -> scalars().all()
+    """
+    session = AsyncMock()
+
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = application
+
+    cond_result = MagicMock()
+    cond_result.scalars.return_value.all.return_value = conditions
+
+    session.execute = AsyncMock(side_effect=[app_result, cond_result])
+    return session
+
+
+def _make_respond_session(application, condition):
+    """Build a mock session for the respond-to-condition endpoint.
+
+    The respond service runs two queries:
+      1. Application lookup -> unique().scalar_one_or_none()
+      2. Condition lookup -> scalar_one_or_none()
+    Then commits and refreshes.
+    """
+    session = AsyncMock()
+
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = application
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = condition
+
+    session.execute = AsyncMock(side_effect=[app_result, cond_result])
+    return session
+
+
+class TestBorrowerListConditions:
+    """Borrower can list conditions on own application."""
+
+    def test_borrower_sees_conditions(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        conditions = [
+            _mock_condition(id=1, description="Verify employment", status=ConditionStatus.OPEN),
+            _mock_condition(
+                id=2,
+                description="Bank statements",
+                status=ConditionStatus.RESPONDED,
+                response_text="Uploaded both months",
+            ),
+        ]
+        session = _make_conditions_session(sarah_app, conditions)
+        client = make_client(borrower_sarah(), session)
+
+        resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 2
+        assert data["data"][0]["description"] == "Verify employment"
+        assert data["data"][0]["status"] == "open"
+        assert data["data"][1]["response_text"] == "Uploaded both months"
+
+    def test_borrower_sees_empty_conditions(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        session = _make_conditions_session(sarah_app, [])
+        client = make_client(borrower_sarah(), session)
+
+        resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 0
+        assert data["data"] == []
+
+    def test_borrower_cannot_see_other_app(self, app, make_client):
+        session = _make_conditions_session(None, [])
+        client = make_client(borrower_sarah(), session)
+
+        resp = client.get("/api/applications/99999/conditions")
+        assert resp.status_code == 404
+
+
+class TestBorrowerRespondToCondition:
+    """Borrower can respond to conditions with text."""
+
+    def test_borrower_responds_to_condition(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        condition = _mock_condition(
+            id=5,
+            description="Explain large deposit",
+            status=ConditionStatus.OPEN,
+        )
+        session = _make_respond_session(sarah_app, condition)
+        client = make_client(borrower_sarah(), session)
+
+        resp = client.post(
+            f"/api/applications/{sarah_app.id}/conditions/5/respond",
+            json={"response_text": "Gift from my parents for down payment"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["id"] == 5
+
+    def test_respond_to_missing_condition(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        session = _make_respond_session(sarah_app, None)
+        client = make_client(borrower_sarah(), session)
+
+        resp = client.post(
+            f"/api/applications/{sarah_app.id}/conditions/999/respond",
+            json={"response_text": "my response"},
+        )
+        assert resp.status_code == 404
+
+
+class TestLoanOfficerConditions:
+    """LO can list conditions on assigned applications."""
+
+    def test_lo_sees_conditions(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        conditions = [
+            _mock_condition(id=1, description="Verify employment"),
+        ]
+        session = _make_conditions_session(sarah_app, conditions)
+        client = make_client(loan_officer(), session)
+
+        resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 1
+
+
+class TestUnderwriterConditions:
+    """Underwriter can list conditions."""
+
+    def test_underwriter_sees_conditions(self, app, make_client):
+        sarah_app = make_app_sarah_1()
+        conditions = [_mock_condition(id=1)]
+        session = _make_conditions_session(sarah_app, conditions)
+        client = make_client(underwriter(), session)
+
+        resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
+        assert resp.status_code == 200
+
+
+class TestProspectBlocked:
+    """Prospect cannot access conditions endpoint."""
+
+    def test_prospect_blocked(self, monkeypatch, app, make_client):
+        from src.core.config import settings
+
+        monkeypatch.setattr(settings, "AUTH_DISABLED", False)
+
+        session = AsyncMock()
+        client = make_client(prospect(), session)
+        resp = client.get("/api/applications/101/conditions")
+        assert resp.status_code == 403

--- a/packages/api/tests/integration/test_conditions.py
+++ b/packages/api/tests/integration/test_conditions.py
@@ -1,0 +1,188 @@
+# This project was developed with assistance from AI tools.
+"""Condition listing and response with real PostgreSQL."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+async def _add_conditions(db_session, app_id, issued_by="maria-uw"):
+    """Insert test conditions and return their IDs."""
+    from db.enums import ConditionSeverity, ConditionStatus
+    from db.models import Condition
+
+    c1 = Condition(
+        application_id=app_id,
+        description="Explain the large deposit on your bank statement",
+        severity=ConditionSeverity.PRIOR_TO_APPROVAL,
+        status=ConditionStatus.OPEN,
+        issued_by=issued_by,
+    )
+    c2 = Condition(
+        application_id=app_id,
+        description="Provide signed employment verification letter",
+        severity=ConditionSeverity.PRIOR_TO_APPROVAL,
+        status=ConditionStatus.OPEN,
+        issued_by=issued_by,
+    )
+    c3 = Condition(
+        application_id=app_id,
+        description="Title insurance commitment",
+        severity=ConditionSeverity.PRIOR_TO_CLOSING,
+        status=ConditionStatus.CLEARED,
+        issued_by=issued_by,
+        cleared_by=issued_by,
+    )
+    db_session.add_all([c1, c2, c3])
+    await db_session.flush()
+    return c1.id, c2.id, c3.id
+
+
+class TestListConditions:
+    """GET /applications/{id}/conditions."""
+
+    async def test_borrower_sees_all_conditions(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        c1_id, c2_id, c3_id = await _add_conditions(db_session, seed_data.sarah_app1.id)
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/conditions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 3
+        statuses = {c["status"] for c in data["data"]}
+        assert "open" in statuses
+        assert "cleared" in statuses
+        await client.aclose()
+
+    async def test_open_only_filter(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        await _add_conditions(db_session, seed_data.sarah_app1.id)
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.get(
+            f"/api/applications/{seed_data.sarah_app1.id}/conditions?open_only=true"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Only OPEN and RESPONDED statuses, not CLEARED
+        assert data["count"] == 2
+        statuses = {c["status"] for c in data["data"]}
+        assert "cleared" not in statuses
+        await client.aclose()
+
+    async def test_borrower_blocked_from_other_app(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        await _add_conditions(db_session, seed_data.michael_app.id)
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.get(f"/api/applications/{seed_data.michael_app.id}/conditions")
+        assert resp.status_code == 404
+        await client.aclose()
+
+    async def test_lo_sees_assigned_app_conditions(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import loan_officer
+
+        await _add_conditions(db_session, seed_data.sarah_app1.id)
+
+        client = await client_factory(loan_officer())
+        resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/conditions")
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 3
+        await client.aclose()
+
+
+class TestRespondToCondition:
+    """POST /applications/{id}/conditions/{cid}/respond."""
+
+    async def test_borrower_responds_to_open_condition(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        c1_id, _, _ = await _add_conditions(db_session, seed_data.sarah_app1.id)
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.post(
+            f"/api/applications/{seed_data.sarah_app1.id}/conditions/{c1_id}/respond",
+            json={"response_text": "Gift from my parents for the down payment"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["id"] == c1_id
+        assert data["status"] == "responded"
+        assert data["response_text"] == "Gift from my parents for the down payment"
+        await client.aclose()
+
+    async def test_respond_updates_status_to_responded(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        c1_id, _, _ = await _add_conditions(db_session, seed_data.sarah_app1.id)
+
+        client = await client_factory(borrower_sarah())
+        # Respond to condition
+        await client.post(
+            f"/api/applications/{seed_data.sarah_app1.id}/conditions/{c1_id}/respond",
+            json={"response_text": "Gift from parents"},
+        )
+
+        # Verify via list endpoint - filter open_only to see it changed from open
+        resp = await client.get(
+            f"/api/applications/{seed_data.sarah_app1.id}/conditions?open_only=true"
+        )
+        data = resp.json()
+        responded = [c for c in data["data"] if c["id"] == c1_id]
+        assert len(responded) == 1
+        assert responded[0]["status"] == "responded"
+        assert responded[0]["response_text"] == "Gift from parents"
+        await client.aclose()
+
+    async def test_respond_to_nonexistent_condition(self, client_factory, seed_data, db_session):
+        from tests.functional.personas import borrower_sarah
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.post(
+            f"/api/applications/{seed_data.sarah_app1.id}/conditions/99999/respond",
+            json={"response_text": "my response"},
+        )
+        assert resp.status_code == 404
+        await client.aclose()
+
+    async def test_borrower_blocked_from_other_app_respond(
+        self, client_factory, seed_data, db_session
+    ):
+        from tests.functional.personas import borrower_sarah
+
+        c1_id, _, _ = await _add_conditions(db_session, seed_data.michael_app.id)
+
+        client = await client_factory(borrower_sarah())
+        resp = await client.post(
+            f"/api/applications/{seed_data.michael_app.id}/conditions/{c1_id}/respond",
+            json={"response_text": "my response"},
+        )
+        assert resp.status_code == 404
+        await client.aclose()
+
+
+class TestDocumentConditionLink:
+    """Document linking to conditions via the condition_id FK."""
+
+    async def test_document_has_condition_id_column(self, db_session, seed_data):
+        """Verify the condition_id column exists and can be set."""
+        from db.models import Document
+        from sqlalchemy import select
+
+        # seed_data.doc1 has no condition
+        result = await db_session.execute(select(Document).where(Document.id == seed_data.doc1.id))
+        doc = result.scalar_one()
+        assert doc.condition_id is None
+
+        # Link to a condition
+        c1_id, _, _ = await _add_conditions(db_session, seed_data.sarah_app1.id)
+        doc.condition_id = c1_id
+        await db_session.flush()
+
+        result2 = await db_session.execute(select(Document).where(Document.id == seed_data.doc1.id))
+        updated = result2.scalar_one()
+        assert updated.condition_id == c1_id

--- a/packages/api/tests/test_condition.py
+++ b/packages/api/tests/test_condition.py
@@ -1,0 +1,399 @@
+# This project was developed with assistance from AI tools.
+"""Tests for condition service, endpoints, and agent tools."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.borrower_tools import list_conditions, respond_to_condition_tool
+from src.schemas.condition import ConditionItem, ConditionListResponse, ConditionRespondRequest
+from src.services.condition import (
+    get_conditions,
+    link_document_to_condition,
+    respond_to_condition,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _state(user_id="sarah-uuid", role="borrower"):
+    return {"user_id": user_id, "user_role": role}
+
+
+def _mock_condition(
+    id=1,
+    description="Verify employment",
+    severity="prior_to_approval",
+    status="open",
+    response_text=None,
+    issued_by="maria-uuid",
+    application_id=100,
+):
+    c = MagicMock()
+    c.id = id
+    c.description = description
+    c.severity = MagicMock()
+    c.severity.value = severity
+    c.status = MagicMock()
+    c.status.value = status
+    c.response_text = response_text
+    c.issued_by = issued_by
+    c.application_id = application_id
+    c.created_at = MagicMock()
+    c.created_at.isoformat.return_value = "2026-02-20T00:00:00+00:00"
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_condition_item_schema():
+    item = ConditionItem(
+        id=1,
+        description="Verify employment",
+        severity="prior_to_approval",
+        status="open",
+    )
+    assert item.id == 1
+    assert item.status == "open"
+
+
+def test_condition_list_response_schema():
+    resp = ConditionListResponse(
+        data=[
+            ConditionItem(id=1, description="Verify employment"),
+            ConditionItem(id=2, description="Bank statements"),
+        ],
+        count=2,
+    )
+    assert resp.count == 2
+    assert len(resp.data) == 2
+
+
+def test_condition_respond_request_schema():
+    req = ConditionRespondRequest(response_text="Gift from parents for down payment")
+    assert req.response_text == "Gift from parents for down payment"
+
+
+# ---------------------------------------------------------------------------
+# Service: get_conditions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_conditions_returns_none_for_out_of_scope():
+    session = AsyncMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = None
+    session.execute.return_value = app_result
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_conditions(session, user, 999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_conditions_returns_empty_list_when_no_conditions():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    cond_result = MagicMock()
+    cond_result.scalars.return_value.all.return_value = []
+
+    session.execute.side_effect = [app_result, cond_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_conditions(session, user, 100)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_get_conditions_returns_condition_list():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    c1 = _mock_condition(id=1, description="Verify employment", status="open")
+    c2 = _mock_condition(
+        id=2,
+        description="Bank statements",
+        status="responded",
+        response_text="Uploaded both months",
+    )
+    cond_result = MagicMock()
+    cond_result.scalars.return_value.all.return_value = [c1, c2]
+
+    session.execute.side_effect = [app_result, cond_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await get_conditions(session, user, 100)
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+    assert result[0]["status"] == "open"
+    assert result[1]["response_text"] == "Uploaded both months"
+
+
+# ---------------------------------------------------------------------------
+# Service: respond_to_condition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_respond_to_condition_out_of_scope():
+    session = AsyncMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = None
+    session.execute.return_value = app_result
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await respond_to_condition(session, user, 999, 1, "my response")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_respond_to_condition_condition_not_found():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = None
+
+    session.execute.side_effect = [app_result, cond_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await respond_to_condition(session, user, 100, 999, "my response")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_respond_to_condition_records_response():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    from db.enums import ConditionStatus
+
+    cond = MagicMock()
+    cond.id = 5
+    cond.description = "Explain large deposit"
+    cond.status = ConditionStatus.OPEN
+    cond.response_text = None
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = cond
+
+    session.execute.side_effect = [app_result, cond_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await respond_to_condition(session, user, 100, 5, "Gift from my parents")
+
+    assert cond.response_text == "Gift from my parents"
+    assert cond.status == ConditionStatus.RESPONDED
+    session.commit.assert_awaited_once()
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Service: link_document_to_condition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_link_document_to_condition_out_of_scope():
+    session = AsyncMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = None
+    session.execute.return_value = app_result
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await link_document_to_condition(session, user, 999, 1, 1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_link_document_to_condition_success():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    from db.enums import ConditionStatus
+
+    cond = MagicMock()
+    cond.id = 3
+    cond.description = "Upload employment verification"
+    cond.status = ConditionStatus.OPEN
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = cond
+
+    doc = MagicMock()
+    doc.id = 10
+    doc.condition_id = None
+
+    doc_result = MagicMock()
+    doc_result.scalar_one_or_none.return_value = doc
+
+    session.execute.side_effect = [app_result, cond_result, doc_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await link_document_to_condition(session, user, 100, 3, 10)
+
+    assert doc.condition_id == 3
+    assert cond.status == ConditionStatus.RESPONDED
+    session.commit.assert_awaited_once()
+    assert result is not None
+    assert result["document_id"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Agent tool: list_conditions
+# ---------------------------------------------------------------------------
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_conditions")
+async def test_tool_list_conditions_with_open(mock_service, mock_session_cls):
+    mock_service.return_value = [
+        {
+            "id": 1,
+            "description": "Verify employment",
+            "severity": "prior_to_approval",
+            "status": "open",
+            "response_text": None,
+            "issued_by": "maria-uuid",
+            "created_at": "2026-02-20T00:00:00+00:00",
+        },
+        {
+            "id": 2,
+            "description": "Bank statements",
+            "severity": "prior_to_approval",
+            "status": "responded",
+            "response_text": "Uploaded both months",
+            "issued_by": "maria-uuid",
+            "created_at": "2026-02-20T00:00:00+00:00",
+        },
+    ]
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await list_conditions.ainvoke({"application_id": 100, "state": _state()})
+
+    assert "Verify employment" in result
+    assert "condition #1" in result
+    assert "1 condition(s)" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_conditions")
+async def test_tool_list_conditions_none_pending(mock_service, mock_session_cls):
+    mock_service.return_value = []
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await list_conditions.ainvoke({"application_id": 100, "state": _state()})
+
+    assert "no pending conditions" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.get_conditions")
+async def test_tool_list_conditions_not_found(mock_service, mock_session_cls):
+    mock_service.return_value = None
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await list_conditions.ainvoke({"application_id": 999, "state": _state()})
+
+    assert "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# Agent tool: respond_to_condition_tool
+# ---------------------------------------------------------------------------
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.respond_to_condition")
+async def test_tool_respond_success(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "id": 5,
+        "description": "Explain large deposit",
+        "status": "responded",
+        "response_text": "Gift from parents",
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await respond_to_condition_tool.ainvoke(
+        {
+            "application_id": 100,
+            "condition_id": 5,
+            "response_text": "Gift from parents",
+            "state": _state(),
+        }
+    )
+
+    assert "Recorded" in result
+    assert "condition #5" in result
+    assert "underwriter will review" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.respond_to_condition")
+async def test_tool_respond_not_found(mock_service, mock_session_cls):
+    mock_service.return_value = None
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await respond_to_condition_tool.ainvoke(
+        {
+            "application_id": 100,
+            "condition_id": 999,
+            "response_text": "my response",
+            "state": _state(),
+        }
+    )
+
+    assert "not found" in result

--- a/packages/db/alembic/versions/650767a5a0cd_add_condition_response_text_and_.py
+++ b/packages/db/alembic/versions/650767a5a0cd_add_condition_response_text_and_.py
@@ -1,0 +1,36 @@
+"""add condition response_text and document condition_id
+
+Revision ID: 650767a5a0cd
+Revises: b8c9d0e1f2a3
+Create Date: 2026-02-25 18:52:44.265862
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "650767a5a0cd"
+down_revision = "b8c9d0e1f2a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("conditions", sa.Column("response_text", sa.Text(), nullable=True))
+    op.add_column("documents", sa.Column("condition_id", sa.Integer(), nullable=True))
+    op.create_index(op.f("ix_documents_condition_id"), "documents", ["condition_id"], unique=False)
+    op.create_foreign_key(
+        "fk_documents_condition_id",
+        "documents",
+        "conditions",
+        ["condition_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_documents_condition_id", "documents", type_="foreignkey")
+    op.drop_index(op.f("ix_documents_condition_id"), table_name="documents")
+    op.drop_column("documents", "condition_id")
+    op.drop_column("conditions", "response_text")

--- a/packages/db/src/db/models.py
+++ b/packages/db/src/db/models.py
@@ -208,12 +208,14 @@ class Condition(Base):
         nullable=False,
         default=ConditionStatus.OPEN,
     )
+    response_text = Column(Text, nullable=True)
     issued_by = Column(String(255), nullable=True)
     cleared_by = Column(String(255), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     application = relationship("Application", back_populates="conditions")
+    documents = relationship("Document", back_populates="condition")
 
     def __repr__(self):
         return f"<Condition(id={self.id}, status='{self.status}')>"
@@ -255,6 +257,9 @@ class Document(Base):
     borrower_id = Column(
         Integer, ForeignKey("borrowers.id", ondelete="SET NULL"), nullable=True, index=True,
     )
+    condition_id = Column(
+        Integer, ForeignKey("conditions.id", ondelete="SET NULL"), nullable=True, index=True,
+    )
     doc_type = Column(
         Enum(DocumentType, name="document_type", native_enum=False),
         nullable=False,
@@ -271,6 +276,7 @@ class Document(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     application = relationship("Application", back_populates="documents")
+    condition = relationship("Condition", back_populates="documents")
     extractions = relationship(
         "DocumentExtraction", back_populates="document", cascade="all, delete-orphan",
     )


### PR DESCRIPTION
## Summary

- Add condition listing and response endpoints with full data scope enforcement
- Borrowers can view underwriting conditions on their applications and respond with text explanations
- Agent tools (`list_conditions`, `respond_to_condition_tool`) integrated into borrower assistant for conversational condition handling
- DB migration adds `response_text` column on conditions and `condition_id` FK on documents

## Changes

**DB (`packages/db`):**
- `response_text` (Text, nullable) on Condition model
- `condition_id` FK (Integer, nullable, SET NULL) on Document model
- Bidirectional relationships: `Condition.documents`, `Document.condition`
- Alembic migration `650767a5a0cd`

**Service (`packages/api/src/services/condition.py`):**
- `get_conditions()` -- list with data scope filtering, optional `open_only` filter
- `respond_to_condition()` -- records text response, OPEN -> RESPONDED status transition
- `link_document_to_condition()` -- links document to condition via FK

**REST endpoints:**
- `GET /applications/{id}/conditions?open_only=bool`
- `POST /applications/{id}/conditions/{cid}/respond`

**Agent tools:**
- `list_conditions` -- formatted output of open/responded conditions
- `respond_to_condition_tool` -- records borrower response with confirmation

**Borrower assistant:**
- Updated system prompt with UNDERWRITING CONDITIONS behavioral rules
- Both tools added to assistant toolset

## Test plan

- [x] 16 unit tests (3 schema + 8 service + 5 tool)
- [x] 8 functional tests (borrower CRUD, LO/UW access, prospect blocked)
- [x] 9 integration tests against real PostgreSQL (list, filter, respond, cross-app blocking, document link)
- [x] Live REST endpoint testing (list, filter, respond, persistence, 404)
- [x] Live WebSocket agent testing (tool invocation, cross-borrower scope enforcement)
- [x] 472 total tests passing, lint clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>