### PR TITLE
feat(api): agent confirms condition satisfaction (S-2-F28-03)

### DIFF
--- a/config/agents/borrower-assistant.yaml
+++ b/config/agents/borrower-assistant.yaml
@@ -19,6 +19,7 @@ system_prompt: |
   - Check which disclosures have been acknowledged using the disclosure_status tool
   - Check rate lock status using the rate_lock_status tool
   - List and respond to underwriting conditions using list_conditions and respond_to_condition_tool
+  - Check condition satisfaction after document upload using check_condition_satisfaction
   - Explain mortgage concepts, application steps, and required documents
 
   PROACTIVE DOCUMENT GUIDANCE:
@@ -50,6 +51,25 @@ system_prompt: |
   - After recording a response, remind the borrower of any remaining open conditions.
   - Handle partial responses gracefully: if the borrower addresses one condition
     but not another, acknowledge the completed one and prompt for the next.
+
+  CONDITION SATISFACTION ASSESSMENT:
+  - After the borrower responds to a condition (text or document upload), evaluate
+    whether the response adequately addresses the condition.
+  - For text responses: if the explanation is clear and specific (e.g. source of
+    funds, reason for gap), confirm it and tell the borrower the underwriter will
+    review. If the response is vague or incomplete, ask for clarification with a
+    specific follow-up question (e.g. "Can you provide more detail about where
+    the $15,000 came from?").
+  - For document-based conditions: after a document is uploaded for a condition,
+    use check_condition_satisfaction to review the extraction results and quality
+    flags. If the document looks good (no quality issues), confirm to the borrower.
+    If there are quality issues (e.g. unsigned, wrong period, wrong document type),
+    explain what needs to be corrected and ask for a re-upload.
+  - When the borrower has addressed ALL pending conditions, congratulate them:
+    "You've addressed all the conditions. The underwriter will review your
+    responses and let you know if anything else is needed."
+  - Remember: you are collecting and validating responses, not approving conditions.
+    Final clearance happens at the underwriter level.
 
   RATE LOCK AWARENESS:
   - When the borrower asks about their rate lock, interest rate, or closing timeline,
@@ -101,6 +121,9 @@ tools:
   - name: respond_to_condition_tool
     description: "Record a borrower's text response to an underwriting condition"
     allowed_roles: [borrower, admin]
+  - name: check_condition_satisfaction
+    description: "Check whether a condition has been satisfied by reviewing linked documents and extraction results"
+    allowed_roles: [borrower, loan_officer, underwriter, admin]
 
 model_routing:
   strategy: per_query

--- a/packages/api/src/agents/borrower_assistant.py
+++ b/packages/api/src/agents/borrower_assistant.py
@@ -4,7 +4,7 @@
 Tools: product_info, affordability_calc, document_completeness,
 application_status, regulatory_deadlines, acknowledge_disclosure,
 disclosure_status, rate_lock_status, list_conditions,
-respond_to_condition_tool.
+respond_to_condition_tool, check_condition_satisfaction.
 """
 
 import logging
@@ -17,6 +17,7 @@ from .base import build_routed_graph
 from .borrower_tools import (
     acknowledge_disclosure,
     application_status,
+    check_condition_satisfaction,
     disclosure_status,
     document_completeness,
     list_conditions,
@@ -43,6 +44,7 @@ def build_graph(config: dict[str, Any], checkpointer=None):
         rate_lock_status,
         list_conditions,
         respond_to_condition_tool,
+        check_condition_satisfaction,
     ]
 
     tool_descriptions = "\n".join(f"- {t.name}: {t.description}" for t in tools)

--- a/packages/api/tests/test_condition.py
+++ b/packages/api/tests/test_condition.py
@@ -5,9 +5,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.agents.borrower_tools import list_conditions, respond_to_condition_tool
+from src.agents.borrower_tools import (
+    check_condition_satisfaction,
+    list_conditions,
+    respond_to_condition_tool,
+)
 from src.schemas.condition import ConditionItem, ConditionListResponse, ConditionRespondRequest
 from src.services.condition import (
+    check_condition_documents,
     get_conditions,
     link_document_to_condition,
     respond_to_condition,
@@ -188,7 +193,8 @@ async def test_respond_to_condition_condition_not_found():
 
 
 @pytest.mark.asyncio
-async def test_respond_to_condition_records_response():
+@patch("src.services.condition.write_audit_event", new_callable=AsyncMock)
+async def test_respond_to_condition_records_response(mock_audit):
     session = AsyncMock()
 
     app_mock = MagicMock()
@@ -210,6 +216,9 @@ async def test_respond_to_condition_records_response():
 
     user = MagicMock()
     user.data_scope = MagicMock()
+    user.user_id = "sarah-uuid"
+    user.role = MagicMock()
+    user.role.value = "borrower"
 
     result = await respond_to_condition(session, user, 100, 5, "Gift from my parents")
 
@@ -217,6 +226,189 @@ async def test_respond_to_condition_records_response():
     assert cond.status == ConditionStatus.RESPONDED
     session.commit.assert_awaited_once()
     assert result is not None
+
+    # Verify audit event was written
+    mock_audit.assert_awaited_once()
+    audit_call = mock_audit.call_args
+    assert audit_call.kwargs["event_type"] == "condition_response"
+    assert audit_call.kwargs["user_id"] == "sarah-uuid"
+    assert audit_call.kwargs["application_id"] == 100
+    assert audit_call.kwargs["event_data"]["condition_id"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Service: check_condition_documents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_condition_documents_out_of_scope():
+    session = AsyncMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = None
+    session.execute.return_value = app_result
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await check_condition_documents(session, user, 999, 1)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_condition_documents_condition_not_found():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = None
+
+    session.execute.side_effect = [app_result, cond_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await check_condition_documents(session, user, 100, 999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_condition_documents_no_documents():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    from db.enums import ConditionStatus
+
+    cond = MagicMock()
+    cond.id = 5
+    cond.description = "Upload employment verification"
+    cond.status = ConditionStatus.RESPONDED
+    cond.response_text = "I'll upload it soon"
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = cond
+
+    doc_result = MagicMock()
+    doc_result.scalars.return_value.all.return_value = []
+
+    session.execute.side_effect = [app_result, cond_result, doc_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await check_condition_documents(session, user, 100, 5)
+    assert result is not None
+    assert result["condition_id"] == 5
+    assert result["has_documents"] is False
+    assert result["response_text"] == "I'll upload it soon"
+
+
+@pytest.mark.asyncio
+async def test_check_condition_documents_with_docs_and_extractions():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    from db.enums import ConditionStatus
+
+    cond = MagicMock()
+    cond.id = 3
+    cond.description = "Provide signed employment verification"
+    cond.status = ConditionStatus.RESPONDED
+    cond.response_text = None
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = cond
+
+    # Mock document with quality flags
+    doc = MagicMock()
+    doc.id = 10
+    doc.file_path = "uploads/emp_verification.pdf"
+    doc.doc_type = MagicMock()
+    doc.doc_type.value = "employment_verification"
+    doc.status = MagicMock()
+    doc.status.value = "processing_complete"
+    doc.quality_flags = "unsigned"
+    doc.created_at = MagicMock()
+
+    doc_result = MagicMock()
+    doc_result.scalars.return_value.all.return_value = [doc]
+
+    # Mock extraction
+    ext = MagicMock()
+    ext.field_name = "employer_name"
+    ext.field_value = "Acme Corp"
+    ext.confidence = 0.95
+
+    ext_result = MagicMock()
+    ext_result.scalars.return_value.all.return_value = [ext]
+
+    session.execute.side_effect = [app_result, cond_result, doc_result, ext_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await check_condition_documents(session, user, 100, 3)
+    assert result is not None
+    assert result["has_documents"] is True
+    assert result["has_quality_issues"] is True
+    assert len(result["documents"]) == 1
+    assert result["documents"][0]["quality_flags"] == ["unsigned"]
+    assert result["documents"][0]["extractions"][0]["field"] == "employer_name"
+
+
+@pytest.mark.asyncio
+async def test_check_condition_documents_clean_document():
+    session = AsyncMock()
+
+    app_mock = MagicMock()
+    app_result = MagicMock()
+    app_result.unique.return_value.scalar_one_or_none.return_value = app_mock
+
+    from db.enums import ConditionStatus
+
+    cond = MagicMock()
+    cond.id = 3
+    cond.description = "Provide bank statements"
+    cond.status = ConditionStatus.RESPONDED
+    cond.response_text = None
+
+    cond_result = MagicMock()
+    cond_result.scalar_one_or_none.return_value = cond
+
+    doc = MagicMock()
+    doc.id = 11
+    doc.file_path = "uploads/bank_stmt.pdf"
+    doc.doc_type = MagicMock()
+    doc.doc_type.value = "bank_statement"
+    doc.status = MagicMock()
+    doc.status.value = "processing_complete"
+    doc.quality_flags = None
+    doc.created_at = MagicMock()
+
+    doc_result = MagicMock()
+    doc_result.scalars.return_value.all.return_value = [doc]
+
+    ext_result = MagicMock()
+    ext_result.scalars.return_value.all.return_value = []
+
+    session.execute.side_effect = [app_result, cond_result, doc_result, ext_result]
+
+    user = MagicMock()
+    user.data_scope = MagicMock()
+
+    result = await check_condition_documents(session, user, 100, 3)
+    assert result is not None
+    assert result["has_documents"] is True
+    assert result["has_quality_issues"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -394,6 +586,123 @@ async def test_tool_respond_not_found(mock_service, mock_session_cls):
             "response_text": "my response",
             "state": _state(),
         }
+    )
+
+    assert "not found" in result
+
+
+# ---------------------------------------------------------------------------
+# Agent tool: check_condition_satisfaction
+# ---------------------------------------------------------------------------
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.check_condition_documents")
+async def test_tool_check_satisfaction_with_clean_doc(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "condition_id": 3,
+        "description": "Provide signed employment verification",
+        "status": "responded",
+        "response_text": None,
+        "documents": [
+            {
+                "id": 10,
+                "file_path": "uploads/emp_letter.pdf",
+                "doc_type": "employment_verification",
+                "status": "processing_complete",
+                "quality_flags": [],
+                "extractions": [
+                    {"field": "employer_name", "value": "Acme Corp", "confidence": 0.95},
+                ],
+            },
+        ],
+        "has_documents": True,
+        "has_quality_issues": False,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await check_condition_satisfaction.ainvoke(
+        {"application_id": 100, "condition_id": 3, "state": _state()}
+    )
+
+    assert "emp_letter.pdf" in result
+    assert "employer_name" in result
+    assert "look good" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.check_condition_documents")
+async def test_tool_check_satisfaction_with_quality_issues(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "condition_id": 3,
+        "description": "Provide signed employment verification",
+        "status": "responded",
+        "response_text": None,
+        "documents": [
+            {
+                "id": 10,
+                "file_path": "uploads/emp_letter.pdf",
+                "doc_type": "employment_verification",
+                "status": "processing_complete",
+                "quality_flags": ["unsigned"],
+                "extractions": [],
+            },
+        ],
+        "has_documents": True,
+        "has_quality_issues": True,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await check_condition_satisfaction.ainvoke(
+        {"application_id": 100, "condition_id": 3, "state": _state()}
+    )
+
+    assert "quality issues" in result
+    assert "unsigned" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.check_condition_documents")
+async def test_tool_check_satisfaction_no_documents(mock_service, mock_session_cls):
+    mock_service.return_value = {
+        "condition_id": 5,
+        "description": "Explain large deposit",
+        "status": "responded",
+        "response_text": "Gift from parents",
+        "documents": [],
+        "has_documents": False,
+        "has_quality_issues": False,
+    }
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await check_condition_satisfaction.ainvoke(
+        {"application_id": 100, "condition_id": 5, "state": _state()}
+    )
+
+    assert "No documents" in result
+    assert "text response" in result
+
+
+@patch("src.agents.borrower_tools.SessionLocal")
+@patch("src.agents.borrower_tools.check_condition_documents")
+async def test_tool_check_satisfaction_not_found(mock_service, mock_session_cls):
+    mock_service.return_value = None
+
+    session = AsyncMock()
+    mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+    mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+    result = await check_condition_satisfaction.ainvoke(
+        {"application_id": 999, "condition_id": 1, "state": _state()}
     )
 
     assert "not found" in result


### PR DESCRIPTION
## Summary

- Add `check_condition_satisfaction` agent tool that reviews documents linked to conditions and their extraction results/quality flags
- Agent can now confirm document quality or request corrections from the borrower
- Audit event (`condition_response`) logged when borrower responds to a condition
- System prompt updated with CONDITION SATISFACTION ASSESSMENT behavioral guidance

## Changes

**Service (`packages/api/src/services/condition.py`):**
- `check_condition_documents()` -- queries linked docs, extractions, quality flags for a condition
- `respond_to_condition()` -- now writes `condition_response` audit event with condition details

**Agent tool (`packages/api/src/agents/borrower_tools.py`):**
- `check_condition_satisfaction` -- wraps service, formats output for agent to evaluate:
  - Clean doc: "The document(s) look good"
  - Quality issues: "There are quality issues... asking the borrower to upload a corrected version"
  - Text-only response: "Review it to determine if the explanation is sufficient"

**System prompt (`config/agents/borrower-assistant.yaml`):**
- CONDITION SATISFACTION ASSESSMENT section: text response evaluation, document quality checking, all-conditions-addressed confirmation, clarification request guidance

## Test plan

- [x] 9 new unit tests (5 service: check_condition_documents + audit event verification, 4 tool: clean doc/quality issues/no docs/not found)
- [x] 4 new integration tests (audit trail, check with/without linked docs, out-of-scope)
- [x] Updated functional test mock for audit integration
- [x] Live REST: respond creates audit event in DB with correct data
- [x] Live tool: no linked docs, linked clean doc, linked doc with quality flags, out-of-scope blocked
- [x] Live WebSocket: agent recognizes check_condition_satisfaction tool
- [x] 485 total tests passing, lint clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>