### PR TITLE
fix(api): security hardening for pre-phase-3 audit

### DIFF
--- a/packages/api/src/services/storage.py
+++ b/packages/api/src/services/storage.py
@@ -8,6 +8,7 @@ via ``init_storage_service()``.
 
 import asyncio
 import logging
+import os
 from functools import partial
 
 import boto3
@@ -106,8 +107,12 @@ class StorageService:
 
     @staticmethod
     def build_object_key(application_id: int, document_id: int, filename: str) -> str:
-        """Build the S3 object key: {application_id}/{document_id}/{filename}."""
-        return f"{application_id}/{document_id}/{filename}"
+        """Build the S3 object key: {application_id}/{document_id}/{filename}.
+
+        Strips path components from filename to prevent path traversal attacks.
+        """
+        safe_name = os.path.basename(filename) or f"doc-{document_id}"
+        return f"{application_id}/{document_id}/{safe_name}"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/functional/personas.py
+++ b/packages/api/tests/functional/personas.py
@@ -2,7 +2,7 @@
 """Persona factories for functional tests.
 
 Each function returns a UserContext matching the DataScope built by
-``middleware/auth.py:_build_data_scope()`` for that role. Fixed user IDs
+``middleware/auth.py:build_data_scope()`` for that role. Fixed user IDs
 ensure cross-test consistency.
 """
 

--- a/packages/api/tests/test_borrower_tools.py
+++ b/packages/api/tests/test_borrower_tools.py
@@ -2,7 +2,7 @@
 """Tests for borrower assistant LangGraph tools."""
 
 from datetime import date, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from db.enums import DocumentType
 
@@ -389,9 +389,10 @@ async def test_acknowledge_disclosure_hmda_notice(mock_write, mock_session_cls):
 # ---------------------------------------------------------------------------
 
 
+@patch("src.agents.borrower_tools.app_service")
 @patch("src.agents.borrower_tools.SessionLocal")
 @patch("src.agents.borrower_tools.get_disclosure_status")
-async def test_disclosure_status_all_pending(mock_status, mock_session_cls):
+async def test_disclosure_status_all_pending(mock_status, mock_session_cls, mock_app_svc):
     mock_status.return_value = {
         "application_id": 1,
         "all_acknowledged": False,
@@ -407,6 +408,7 @@ async def test_disclosure_status_all_pending(mock_status, mock_session_cls):
     session = AsyncMock()
     mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
     mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mock_app_svc.get_application = AsyncMock(return_value=MagicMock())
 
     result = await disclosure_status.ainvoke({"application_id": 1, "state": _state()})
 
@@ -416,9 +418,10 @@ async def test_disclosure_status_all_pending(mock_status, mock_session_cls):
     assert "Privacy Notice" in result
 
 
+@patch("src.agents.borrower_tools.app_service")
 @patch("src.agents.borrower_tools.SessionLocal")
 @patch("src.agents.borrower_tools.get_disclosure_status")
-async def test_disclosure_status_all_acknowledged(mock_status, mock_session_cls):
+async def test_disclosure_status_all_acknowledged(mock_status, mock_session_cls, mock_app_svc):
     mock_status.return_value = {
         "application_id": 1,
         "all_acknowledged": True,
@@ -434,6 +437,7 @@ async def test_disclosure_status_all_acknowledged(mock_status, mock_session_cls)
     session = AsyncMock()
     mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
     mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mock_app_svc.get_application = AsyncMock(return_value=MagicMock())
 
     result = await disclosure_status.ainvoke({"application_id": 1, "state": _state()})
 
@@ -442,9 +446,10 @@ async def test_disclosure_status_all_acknowledged(mock_status, mock_session_cls)
     assert "Pending:" not in result
 
 
+@patch("src.agents.borrower_tools.app_service")
 @patch("src.agents.borrower_tools.SessionLocal")
 @patch("src.agents.borrower_tools.get_disclosure_status")
-async def test_disclosure_status_partial(mock_status, mock_session_cls):
+async def test_disclosure_status_partial(mock_status, mock_session_cls, mock_app_svc):
     mock_status.return_value = {
         "application_id": 1,
         "all_acknowledged": False,
@@ -455,6 +460,7 @@ async def test_disclosure_status_partial(mock_status, mock_session_cls):
     session = AsyncMock()
     mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
     mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+    mock_app_svc.get_application = AsyncMock(return_value=MagicMock())
 
     result = await disclosure_status.ainvoke({"application_id": 1, "state": _state()})
 

--- a/packages/api/tests/test_intake.py
+++ b/packages/api/tests/test_intake.py
@@ -12,7 +12,7 @@ def _make_user(user_id="borrower-1", role="borrower"):
     """Build a mock UserContext."""
     from db.enums import UserRole
 
-    from src.middleware.auth import _build_data_scope
+    from src.middleware.auth import build_data_scope
     from src.schemas.auth import UserContext
 
     r = UserRole(role)
@@ -21,7 +21,7 @@ def _make_user(user_id="borrower-1", role="borrower"):
         role=r,
         email=f"{user_id}@summit-cap.local",
         name=user_id,
-        data_scope=_build_data_scope(r, user_id),
+        data_scope=build_data_scope(r, user_id),
     )
 
 

--- a/packages/api/tests/test_safety.py
+++ b/packages/api/tests/test_safety.py
@@ -47,12 +47,12 @@ def test_parse_empty_response_treated_as_safe():
     assert result.is_safe is True
 
 
-# -- Fail-open behavior (critical design decision) --
+# -- Failure behavior (input=fail-closed, output=fail-open) --
 
 
 @pytest.mark.asyncio
-async def test_input_check_fails_open_on_llm_error():
-    """should return is_safe=True when the safety model is unreachable."""
+async def test_input_check_fails_closed_on_llm_error():
+    """should return is_safe=False when the safety model is unreachable (fail-closed)."""
     mock_llm = AsyncMock()
     mock_llm.ainvoke.side_effect = ConnectionError("model unreachable")
 
@@ -60,7 +60,8 @@ async def test_input_check_fails_open_on_llm_error():
     checker._llm = mock_llm
 
     result = await checker.check_input("anything")
-    assert result.is_safe is True
+    assert result.is_safe is False
+    assert result.explanation == "Safety check unavailable"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Security hardening fixes from the pre-Phase 3 consolidated audit:

- **C-4**: Make JWKS functions async with `httpx.AsyncClient` (was blocking the event loop with sync `httpx.get()`)
- **C-10**: Change safety input shield from fail-open to fail-closed — blocks user input when Llama Guard is unreachable
- **W-11**: Sanitize filenames in S3 object key construction via `os.path.basename()` to prevent path traversal
- **W-23**: Add data scope authorization check to `disclosure_status` borrower tool — was querying without verifying access
- **S-15**: Rename `_build_data_scope` to `build_data_scope` — used across modules, should be public API

## Test plan

- [x] All 564 tests pass (`AUTH_DISABLED=true pytest -v`)
- [x] Ruff lint clean
- [x] Safety test updated to verify fail-closed behavior on input shield errors
- [x] Disclosure tool tests updated to mock `app_service.get_application` authorization check
- [x] HMDA isolation check passed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>