### PR TITLE
fix(api): state machine + enum consistency for pre-phase-3 audit

### DIFF
--- a/packages/api/src/services/intake.py
+++ b/packages/api/src/services/intake.py
@@ -23,12 +23,7 @@ from ..services.scope import apply_data_scope
 
 logger = logging.getLogger(__name__)
 
-# Terminal stages -- applications in these stages are not considered "active"
-_TERMINAL_STAGES = {
-    ApplicationStage.WITHDRAWN,
-    ApplicationStage.DENIED,
-    ApplicationStage.CLOSED,
-}
+_TERMINAL_STAGES = ApplicationStage.terminal_stages()
 
 
 async def find_active_application(

--- a/packages/api/src/services/status.py
+++ b/packages/api/src/services/status.py
@@ -87,15 +87,11 @@ STAGE_INFO: dict[str, StageInfo] = {
     ),
 }
 
-_TERMINAL_STAGES = {
-    ApplicationStage.CLOSED.value,
-    ApplicationStage.DENIED.value,
-    ApplicationStage.WITHDRAWN.value,
-}
+_TERMINAL_STAGES = ApplicationStage.terminal_stages()
 
 _RESOLVED_CONDITION_STATUSES = {
-    ConditionStatus.CLEARED.value,
-    ConditionStatus.WAIVED.value,
+    ConditionStatus.CLEARED,
+    ConditionStatus.WAIVED,
 }
 
 

--- a/packages/db/src/db/enums.py
+++ b/packages/db/src/db/enums.py
@@ -22,6 +22,32 @@ class ApplicationStage(str, enum.Enum):
     WITHDRAWN = "withdrawn"
 
 
+    @classmethod
+    def terminal_stages(cls) -> frozenset["ApplicationStage"]:
+        """Stages where an application is no longer active."""
+        return frozenset({cls.CLOSED, cls.DENIED, cls.WITHDRAWN})
+
+    @classmethod
+    def valid_transitions(cls) -> dict["ApplicationStage", frozenset["ApplicationStage"]]:
+        """Allowed stage transitions in the lending lifecycle."""
+        return {
+            cls.INQUIRY: frozenset({cls.PREQUALIFICATION, cls.APPLICATION, cls.WITHDRAWN}),
+            cls.PREQUALIFICATION: frozenset({cls.APPLICATION, cls.DENIED, cls.WITHDRAWN}),
+            cls.APPLICATION: frozenset({cls.PROCESSING, cls.DENIED, cls.WITHDRAWN}),
+            cls.PROCESSING: frozenset({cls.UNDERWRITING, cls.DENIED, cls.WITHDRAWN}),
+            cls.UNDERWRITING: frozenset(
+                {cls.CONDITIONAL_APPROVAL, cls.CLEAR_TO_CLOSE, cls.DENIED, cls.WITHDRAWN}
+            ),
+            cls.CONDITIONAL_APPROVAL: frozenset(
+                {cls.CLEAR_TO_CLOSE, cls.DENIED, cls.WITHDRAWN}
+            ),
+            cls.CLEAR_TO_CLOSE: frozenset({cls.CLOSED, cls.WITHDRAWN}),
+            cls.CLOSED: frozenset(),
+            cls.DENIED: frozenset(),
+            cls.WITHDRAWN: frozenset(),
+        }
+
+
 class UserRole(str, enum.Enum):
     ADMIN = "admin"
     PROSPECT = "prospect"


### PR DESCRIPTION
## Summary

State machine enforcement and enum consistency fixes from the pre-Phase 3 consolidated audit:

- **C-2**: Add `VALID_TRANSITIONS` map on `ApplicationStage` and `transition_stage()` service function. Remove `stage` from `_UPDATABLE_FIELDS` so `update_application()` can no longer set arbitrary stages. The PATCH route extracts stage changes and routes them through the state machine, returning 422 for invalid transitions.
- **W-5**: Standardize enum comparisons in `status.py` to use enum members instead of `.value` strings (e.g., `ConditionStatus.CLEARED` not `ConditionStatus.CLEARED.value`)
- **W-24**: Define `terminal_stages()` classmethod on `ApplicationStage` in `db/enums.py` and import from both `intake.py` and `status.py` (was defined independently in both files with different types)

## Test plan

- [x] All 564 tests pass (`AUTH_DISABLED=true pytest -v`)
- [x] Ruff lint clean
- [x] HMDA isolation check passed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>