### PR TITLE
fix(api): bug fixes + code quality for pre-phase-3 audit

### DIFF
--- a/packages/api/src/services/intake_validation.py
+++ b/packages/api/src/services/intake_validation.py
@@ -6,6 +6,7 @@ collected during conversational intake.
 """
 
 import re
+from collections.abc import Callable
 from datetime import date, datetime
 
 
@@ -170,7 +171,7 @@ def validate_employment_status(value: str) -> tuple[bool, str, str | None]:
         return False, f"Unknown status. Valid: {', '.join(valid)}", None
 
 
-_VALIDATORS: dict[str, callable] = {
+_VALIDATORS: dict[str, Callable] = {
     "ssn": validate_ssn,
     "date_of_birth": validate_dob,
     "email": validate_email,

--- a/packages/api/src/services/seed/fixtures.py
+++ b/packages/api/src/services/seed/fixtures.py
@@ -200,7 +200,7 @@ ACTIVE_APPLICATIONS: list[dict] = [
             {
                 "doc_type": DocumentType.PAY_STUB,
                 "status": DocumentStatus.FLAGGED_FOR_RESUBMISSION,
-                "quality_flags": "Document partially illegible, please resubmit",
+                "quality_flags": json.dumps(["partially_illegible"]),
             },
         ],
     },

--- a/packages/api/tests/test_intake.py
+++ b/packages/api/tests/test_intake.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.services.intake import _mask_ssn, start_application
+from src.middleware.pii import mask_ssn
+from src.services.intake import start_application
 
 
 def _make_user(user_id="borrower-1", role="borrower"):
@@ -293,18 +294,18 @@ async def test_update_tool_all_fields_complete():
 
 def test_mask_ssn_full():
     """should mask all but last 4 digits of a full SSN."""
-    assert _mask_ssn("078-05-1120") == "***-**-1120"
+    assert mask_ssn("078-05-1120") == "***-**-1120"
 
 
 def test_mask_ssn_digits_only():
     """should handle SSNs without dashes."""
-    assert _mask_ssn("078051120") == "***-**-1120"
+    assert mask_ssn("078051120") == "***-**-1120"
 
 
 def test_mask_ssn_none():
-    """should return None for empty/None input."""
-    assert _mask_ssn(None) is None
-    assert _mask_ssn("") is None
+    """should return None for None, masked placeholder for empty."""
+    assert mask_ssn(None) is None
+    assert mask_ssn("") == "***-**-****"
 
 
 # -- Field section consistency --


### PR DESCRIPTION
## Summary

Bug fixes and code quality improvements from the pre-Phase 3 consolidated audit:

- **C-1**: Fix `quality_flags` parsing in condition service -- was using `.split(",")` on JSON-serialized arrays. Now parses as JSON with CSV fallback. Also fix seeder fixture to store JSON array instead of plain string.
- **C-13**: Rewrite `test_tool_auth.py` to invoke the actual `tool_auth` node function from the compiled graph instead of reimplementing the auth logic in tests. Tests now exercise real production code.
- **W-20**: Remove duplicate `_mask_ssn` from `intake.py` -- import canonical `mask_ssn` from `middleware/pii.py`.
- **W-25**: Retain background extraction task reference with `done_callback` to prevent silent exception loss. Uses `_extraction_tasks` set with `discard` callback.
- **S-9**: Replace builtin `callable` with `Callable` from `collections.abc` in type annotations.
- **S-13**: Only render first page of scanned PDFs for extraction (was rendering all pages but only using first).

## Test plan

- [x] All 563 tests pass (`AUTH_DISABLED=true pytest -v`)
- [x] Ruff lint clean
- [x] HMDA isolation check passed
- [x] Test count change: -1 (removed `test_tool_auth_logs_denial` that only tested mock setup)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>