### PR TITLE
refactor(api): agent architecture cleanup (W-1, W-6, W-21, S-17)

### DIFF
--- a/packages/api/src/agents/borrower_assistant.py
+++ b/packages/api/src/agents/borrower_assistant.py
@@ -8,13 +8,9 @@ acknowledge_disclosure, disclosure_status, rate_lock_status,
 list_conditions, respond_to_condition_tool, check_condition_satisfaction.
 """
 
-import logging
 from typing import Any
 
-from langchain_openai import ChatOpenAI
-
-from ..inference.config import get_model_config, get_model_tiers
-from .base import build_routed_graph
+from .base import build_agent_graph
 from .borrower_tools import (
     acknowledge_disclosure,
     application_status,
@@ -32,54 +28,27 @@ from .borrower_tools import (
 )
 from .tools import affordability_calc, product_info
 
-logger = logging.getLogger(__name__)
-
 
 def build_graph(config: dict[str, Any], checkpointer=None):
     """Build a routed LangGraph graph for the borrower assistant."""
-    system_prompt = config.get("system_prompt", "You are a helpful mortgage assistant.")
-    tools = [
-        product_info,
-        affordability_calc,
-        start_application,
-        update_application_data,
-        get_application_summary,
-        document_completeness,
-        document_processing_status,
-        application_status,
-        regulatory_deadlines,
-        acknowledge_disclosure,
-        disclosure_status,
-        rate_lock_status,
-        list_conditions,
-        respond_to_condition_tool,
-        check_condition_satisfaction,
-    ]
-
-    tool_descriptions = "\n".join(f"- {t.name}: {t.description}" for t in tools)
-
-    # Extract tool -> allowed_roles mapping from YAML config
-    tool_allowed_roles: dict[str, list[str]] = {}
-    for tool_cfg in config.get("tools", []):
-        name = tool_cfg.get("name")
-        allowed = tool_cfg.get("allowed_roles")
-        if name and allowed:
-            tool_allowed_roles[name] = allowed
-
-    llms: dict[str, ChatOpenAI] = {}
-    for tier in get_model_tiers():
-        model_cfg = get_model_config(tier)
-        llms[tier] = ChatOpenAI(
-            model=model_cfg["model_name"],
-            base_url=model_cfg["endpoint"],
-            api_key=model_cfg.get("api_key", "not-needed"),
-        )
-
-    return build_routed_graph(
-        system_prompt=system_prompt,
-        tools=tools,
-        llms=llms,
-        tool_descriptions=tool_descriptions,
-        tool_allowed_roles=tool_allowed_roles,
+    return build_agent_graph(
+        config,
+        [
+            product_info,
+            affordability_calc,
+            start_application,
+            update_application_data,
+            get_application_summary,
+            document_completeness,
+            document_processing_status,
+            application_status,
+            regulatory_deadlines,
+            acknowledge_disclosure,
+            disclosure_status,
+            rate_lock_status,
+            list_conditions,
+            respond_to_condition_tool,
+            check_condition_satisfaction,
+        ],
         checkpointer=checkpointer,
     )

--- a/packages/api/src/agents/public_assistant.py
+++ b/packages/api/src/agents/public_assistant.py
@@ -4,47 +4,16 @@
 Tools: product_info, affordability_calc (no customer data access).
 """
 
-import logging
 from typing import Any
 
-from langchain_openai import ChatOpenAI
-
-from ..inference.config import get_model_config, get_model_tiers
-from .base import build_routed_graph
+from .base import build_agent_graph
 from .tools import affordability_calc, product_info
-
-logger = logging.getLogger(__name__)
 
 
 def build_graph(config: dict[str, Any], checkpointer=None):
     """Build a routed LangGraph graph for the public assistant."""
-    system_prompt = config.get("system_prompt", "You are a helpful mortgage assistant.")
-    tools = [product_info, affordability_calc]
-
-    tool_descriptions = "\n".join(f"- {t.name}: {t.description}" for t in tools)
-
-    # Extract tool -> allowed_roles mapping from YAML config
-    tool_allowed_roles: dict[str, list[str]] = {}
-    for tool_cfg in config.get("tools", []):
-        name = tool_cfg.get("name")
-        allowed = tool_cfg.get("allowed_roles")
-        if name and allowed:
-            tool_allowed_roles[name] = allowed
-
-    llms: dict[str, ChatOpenAI] = {}
-    for tier in get_model_tiers():
-        model_cfg = get_model_config(tier)
-        llms[tier] = ChatOpenAI(
-            model=model_cfg["model_name"],
-            base_url=model_cfg["endpoint"],
-            api_key=model_cfg.get("api_key", "not-needed"),
-        )
-
-    return build_routed_graph(
-        system_prompt=system_prompt,
-        tools=tools,
-        llms=llms,
-        tool_descriptions=tool_descriptions,
-        tool_allowed_roles=tool_allowed_roles,
+    return build_agent_graph(
+        config,
+        [product_info, affordability_calc],
         checkpointer=checkpointer,
     )

--- a/packages/api/src/routes/_chat_handler.py
+++ b/packages/api/src/routes/_chat_handler.py
@@ -93,6 +93,8 @@ async def run_agent_stream(
     session_id: str,
     user_role: str,
     user_id: str,
+    user_email: str = "",
+    user_name: str = "",
     use_checkpointer: bool,
     messages_fallback: list | None,
 ) -> None:
@@ -164,6 +166,8 @@ async def run_agent_stream(
                         "messages": input_messages,
                         "user_role": user_role,
                         "user_id": user_id,
+                        "user_email": user_email,
+                        "user_name": user_name,
                     },
                     config=config,
                     version="v2",

--- a/packages/api/src/routes/borrower_chat.py
+++ b/packages/api/src/routes/borrower_chat.py
@@ -59,6 +59,8 @@ async def borrower_chat_websocket(ws: WebSocket):
         session_id=session_id,
         user_role=user.role.value,
         user_id=user.user_id,
+        user_email=user.email or "",
+        user_name=user.name or "",
         use_checkpointer=use_checkpointer,
         messages_fallback=messages_fallback,
     )

--- a/packages/api/tests/test_chat.py
+++ b/packages/api/tests/test_chat.py
@@ -206,13 +206,6 @@ async def test_output_shield_replaces_unsafe_response(_fresh_graph, monkeypatch)
     mock_agent_llm.bind_tools.return_value = mock_agent_llm
 
     mock_llms = {"fast_small": mock_classifier, "capable_large": mock_agent_llm}
-    monkeypatch.setattr(
-        "src.agents.public_assistant.get_model_tiers", lambda: ["fast_small", "capable_large"]
-    )
-    monkeypatch.setattr(
-        "src.agents.public_assistant.get_model_config",
-        lambda tier: {"model_name": "test", "endpoint": "http://test", "api_key": "key"},
-    )
 
     from src.agents.base import build_routed_graph
     from src.agents.tools import affordability_calc, product_info


### PR DESCRIPTION
## Summary

Pre-phase-3 audit PR 5/9: Agent architecture refactoring.

- **W-21**: Extract `build_agent_graph()` factory in `base.py` -- eliminates duplicated LLM init, tool_allowed_roles extraction, and `build_routed_graph` boilerplate from both `public_assistant.py` and `borrower_assistant.py`
- **W-6**: Replace if/elif agent dispatch in `registry.py` with `_AGENT_MODULES` dict + `importlib.import_module()` for O(1) lookup and easy extensibility
- **S-17**: Propagate real `user_email`/`user_name` through `AgentState` -> `_chat_handler` -> borrower tools, replacing synthetic placeholder values
- **W-1**: Document session-per-tool-call DB pattern as intentional design decision in `borrower_tools.py` module docstring

## Test plan

- [x] All 563 tests pass (`AUTH_DISABLED=true pytest -v`)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass (format + lint + HMDA isolation)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>