### PR TITLE
feat(api): add rfc 7807 errors, scope helper, response envelopes (C-9, W-22, S-8)

### DIFF
--- a/packages/api/src/routes/applications.py
+++ b/packages/api/src/routes/applications.py
@@ -17,7 +17,12 @@ from ..schemas.application import (
     ApplicationUpdate,
     BorrowerSummary,
 )
-from ..schemas.condition import ConditionListResponse, ConditionRespondRequest
+from ..schemas.condition import (
+    ConditionItem,
+    ConditionListResponse,
+    ConditionRespondRequest,
+    ConditionResponse,
+)
 from ..schemas.rate_lock import RateLockResponse
 from ..schemas.status import ApplicationStatusResponse
 from ..services import application as app_service
@@ -215,6 +220,7 @@ async def list_conditions(
 
 @router.post(
     "/{application_id}/conditions/{condition_id}/respond",
+    response_model=ConditionResponse,
     dependencies=[Depends(require_roles(UserRole.BORROWER, UserRole.ADMIN))],
 )
 async def respond_condition(
@@ -237,7 +243,7 @@ async def respond_condition(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Application or condition not found",
         )
-    return {"data": result}
+    return ConditionResponse(data=ConditionItem(**result))
 
 
 @router.post(

--- a/packages/api/src/routes/documents.py
+++ b/packages/api/src/routes/documents.py
@@ -13,6 +13,7 @@ from ..middleware.auth import CurrentUser, require_roles
 from ..schemas.completeness import CompletenessResponse
 from ..schemas.document import (
     DocumentDetailResponse,
+    DocumentFilePathResponse,
     DocumentListResponse,
     DocumentResponse,
     DocumentUploadResponse,
@@ -179,13 +180,14 @@ async def get_completeness(
 
 @router.get(
     "/documents/{document_id}/content",
+    response_model=DocumentFilePathResponse,
     dependencies=[Depends(require_roles(*_CONTENT_ROLES))],
 )
 async def get_document_content(
     document_id: int,
     user: CurrentUser,
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> DocumentFilePathResponse:
     """Get document content (file path). CEO is blocked at route level (Layer 1)."""
     doc = await doc_service.get_document(session, user, document_id)
     if doc is None:
@@ -200,4 +202,4 @@ async def get_document_content(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(exc),
         ) from exc
-    return {"file_path": file_path}
+    return DocumentFilePathResponse(file_path=file_path)

--- a/packages/api/src/schemas/condition.py
+++ b/packages/api/src/schemas/condition.py
@@ -23,6 +23,12 @@ class ConditionListResponse(BaseModel):
     count: int
 
 
+class ConditionResponse(BaseModel):
+    """Response for a single condition after an update."""
+
+    data: ConditionItem
+
+
 class ConditionRespondRequest(BaseModel):
     """Request body for responding to a condition with text."""
 

--- a/packages/api/src/schemas/document.py
+++ b/packages/api/src/schemas/document.py
@@ -43,6 +43,12 @@ class DocumentUploadResponse(BaseModel):
     created_at: datetime
 
 
+class DocumentFilePathResponse(BaseModel):
+    """Response for document content endpoint."""
+
+    file_path: str
+
+
 class DocumentListResponse(BaseModel):
     """Paginated list of documents."""
 

--- a/packages/api/src/schemas/error.py
+++ b/packages/api/src/schemas/error.py
@@ -1,0 +1,26 @@
+# This project was developed with assistance from AI tools.
+"""RFC 7807 Problem Details error response schema."""
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    """RFC 7807 Problem Details for HTTP APIs.
+
+    See https://datatracker.ietf.org/doc/html/rfc7807
+    """
+
+    type: str = Field(
+        default="about:blank",
+        description="URI reference identifying the problem type.",
+    )
+    title: str = Field(description="Short human-readable summary of the problem.")
+    status: int = Field(description="HTTP status code.")
+    detail: str = Field(
+        default="",
+        description="Human-readable explanation specific to this occurrence.",
+    )
+    request_id: str = Field(
+        default="",
+        description="Correlation ID for tracing this request in logs.",
+    )


### PR DESCRIPTION
## Summary

Pre-phase-3 audit PR 6/9: API error handling and response consistency.

- **C-9**: Global RFC 7807 exception handlers in `main.py` for `HTTPException`, `RequestValidationError`, and unhandled exceptions. New `ErrorResponse` Pydantic schema with `type`, `title`, `status`, `detail`, `request_id` fields.
- **W-22**: Replace 8 duplicated application scope-check blocks across `condition.py` (4 instances), `rate_lock.py` (1), `completeness.py` (1) with single `get_application()` call from the application service. Removes ~70 lines of copy-pasted boilerplate.
- **S-8**: Standardize response envelopes -- add typed `ConditionResponse` and `DocumentFilePathResponse` schemas to replace raw dict returns in route handlers.

## Test plan

- [x] All 563 tests pass (`AUTH_DISABLED=true pytest -v`)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass (format + lint + HMDA isolation)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>