### PR TITLE
chore(api): standardize API schemas and document URL nesting (S-1, S-2, S-5, S-6, S-7)

### DIFF
--- a/.claude/rules/api-conventions.md
+++ b/.claude/rules/api-conventions.md
@@ -9,7 +9,7 @@ paths:
 
 - URLs represent resources (nouns), not actions (verbs): `/users`, not `/getUsers`
 - Use kebab-case for URL paths: `/user-profiles`, not `/userProfiles`
-- Use camelCase for JSON field names: `firstName`, not `first_name`
+- Use snake_case for JSON field names: `first_name`, not `firstName` (Pydantic default; avoids alias boilerplate across 50+ fields)
 - Use plural nouns for collections: `/users`, `/orders`
 - Nest sub-resources under parents: `/users/:id/orders`
 - Keep URLs shallow — max 2 levels of nesting before introducing a top-level resource

--- a/packages/api/src/routes/admin.py
+++ b/packages/api/src/routes/admin.py
@@ -75,7 +75,7 @@ async def get_audit_events(
         events=[
             AuditEventItem(
                 id=e.id,
-                timestamp=str(e.timestamp),
+                timestamp=e.timestamp,
                 event_type=e.event_type,
                 user_id=e.user_id,
                 user_role=e.user_role,

--- a/packages/api/src/routes/applications.py
+++ b/packages/api/src/routes/applications.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..middleware.auth import CurrentUser, require_roles
+from ..schemas import Pagination
 from ..schemas.application import (
     AddBorrowerRequest,
     ApplicationCreate,
@@ -82,7 +83,15 @@ async def list_applications(
         limit=limit,
     )
     items = [_build_app_response(app) for app in applications]
-    return ApplicationListResponse(data=items, count=total)
+    return ApplicationListResponse(
+        data=items,
+        pagination=Pagination(
+            total=total,
+            offset=offset,
+            limit=limit,
+            has_more=(offset + limit < total),
+        ),
+    )
 
 
 @router.get(
@@ -202,7 +211,15 @@ async def list_conditions(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Application not found",
         )
-    return ConditionListResponse(data=result, count=len(result))
+    return ConditionListResponse(
+        data=result,
+        pagination=Pagination(
+            total=len(result),
+            offset=0,
+            limit=len(result),
+            has_more=False,
+        ),
+    )
 
 
 @router.post(

--- a/packages/api/src/schemas/__init__.py
+++ b/packages/api/src/schemas/__init__.py
@@ -1,1 +1,13 @@
 # This project was developed with assistance from AI tools.
+"""Shared schema components."""
+
+from pydantic import BaseModel
+
+
+class Pagination(BaseModel):
+    """Offset-based pagination metadata for list responses."""
+
+    total: int
+    offset: int
+    limit: int
+    has_more: bool

--- a/packages/api/src/schemas/admin.py
+++ b/packages/api/src/schemas/admin.py
@@ -1,6 +1,8 @@
 # This project was developed with assistance from AI tools.
 """Pydantic response models for admin endpoints."""
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -8,7 +10,7 @@ class AuditEventItem(BaseModel):
     """Single audit event in a query response."""
 
     id: int
-    timestamp: str
+    timestamp: datetime
     event_type: str
     user_id: str | None = None
     user_role: str | None = None
@@ -36,7 +38,7 @@ class SeedResponse(BaseModel):
     """Response for POST /api/admin/seed."""
 
     status: str
-    seeded_at: str | None = None
+    seeded_at: datetime | None = None
     config_hash: str | None = None
     borrowers: int | None = None
     active_applications: int | None = None
@@ -48,6 +50,6 @@ class SeedStatusResponse(BaseModel):
     """Response for GET /api/admin/seed/status."""
 
     seeded: bool
-    seeded_at: str | None = None
+    seeded_at: datetime | None = None
     config_hash: str | None = None
     summary: dict | None = None

--- a/packages/api/src/schemas/application.py
+++ b/packages/api/src/schemas/application.py
@@ -7,6 +7,8 @@ from decimal import Decimal
 from db.enums import ApplicationStage, EmploymentStatus, LoanType
 from pydantic import BaseModel, ConfigDict, Field
 
+from . import Pagination
+
 
 class ApplicationCreate(BaseModel):
     """Create a new mortgage application."""
@@ -64,7 +66,7 @@ class ApplicationListResponse(BaseModel):
     """Paginated list of applications."""
 
     data: list[ApplicationResponse]
-    count: int
+    pagination: Pagination
 
 
 class AddBorrowerRequest(BaseModel):

--- a/packages/api/src/schemas/condition.py
+++ b/packages/api/src/schemas/condition.py
@@ -1,7 +1,11 @@
 # This project was developed with assistance from AI tools.
 """Schemas for condition endpoints."""
 
+from datetime import datetime
+
 from pydantic import BaseModel
+
+from . import Pagination
 
 
 class ConditionItem(BaseModel):
@@ -13,14 +17,14 @@ class ConditionItem(BaseModel):
     status: str | None = None
     response_text: str | None = None
     issued_by: str | None = None
-    created_at: str | None = None
+    created_at: datetime | None = None
 
 
 class ConditionListResponse(BaseModel):
     """Response for GET /applications/{id}/conditions."""
 
     data: list[ConditionItem]
-    count: int
+    pagination: Pagination
 
 
 class ConditionResponse(BaseModel):

--- a/packages/api/src/schemas/document.py
+++ b/packages/api/src/schemas/document.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from db.enums import DocumentStatus, DocumentType
 from pydantic import BaseModel, ConfigDict
 
+from . import Pagination
+
 
 class DocumentResponse(BaseModel):
     """Document metadata response (safe for all roles including CEO)."""
@@ -53,4 +55,4 @@ class DocumentListResponse(BaseModel):
     """Paginated list of documents."""
 
     data: list[DocumentResponse]
-    count: int
+    pagination: Pagination

--- a/packages/api/src/schemas/rate_lock.py
+++ b/packages/api/src/schemas/rate_lock.py
@@ -1,6 +1,8 @@
 # This project was developed with assistance from AI tools.
 """Pydantic response models for rate lock endpoints."""
 
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
@@ -10,7 +12,7 @@ class RateLockResponse(BaseModel):
     application_id: int
     status: str  # "active", "expired", "none"
     locked_rate: float | None = None
-    lock_date: str | None = None
-    expiration_date: str | None = None
+    lock_date: datetime | None = None
+    expiration_date: datetime | None = None
     days_remaining: int | None = None
     is_urgent: bool | None = None

--- a/packages/api/tests/functional/test_admin_flow.py
+++ b/packages/api/tests/functional/test_admin_flow.py
@@ -24,7 +24,7 @@ class TestAdminFullAccess:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 3
+        assert data["pagination"]["total"] == 3
 
     def test_get_application_with_unmasked_pii(self, make_client):
         app = make_app_sarah_1()

--- a/packages/api/tests/functional/test_borrower_flow.py
+++ b/packages/api/tests/functional/test_borrower_flow.py
@@ -25,7 +25,7 @@ class TestBorrowerSarahVisibility:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 2
+        assert data["pagination"]["total"] == 2
         assert len(data["data"]) == 2
 
     def test_get_own_application_with_pii(self, make_client):
@@ -57,7 +57,7 @@ class TestBorrowerMichaelVisibility:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 1
+        assert data["pagination"]["total"] == 1
 
 
 class TestBorrowerCannotUpdate:

--- a/packages/api/tests/functional/test_ceo_flow.py
+++ b/packages/api/tests/functional/test_ceo_flow.py
@@ -24,7 +24,7 @@ class TestCeoPiiMasking:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 3
+        assert data["pagination"]["total"] == 3
 
         for item in data["data"]:
             for borrower in item.get("borrowers", []):
@@ -58,9 +58,9 @@ class TestCeoDocumentRestriction:
         doc = make_document()
         client = make_client(ceo(), make_mock_session(single=doc))
 
-        resp = client.get("/api/documents/1")
+        resp = client.get("/api/applications/101/documents/1")
         assert resp.status_code == 200
-        assert "file_path" not in resp.json()
+        assert resp.json()["file_path"] is None
 
     def test_list_documents_metadata_only(self, make_client):
         docs = app_101_documents()
@@ -80,7 +80,7 @@ class TestCeoDocumentRestriction:
         doc = make_document()
         client = make_client(ceo(), make_mock_session(single=doc))
 
-        resp = client.get("/api/documents/1/content")
+        resp = client.get("/api/applications/101/documents/1/content")
         assert resp.status_code == 403
 
 

--- a/packages/api/tests/functional/test_condition_flow.py
+++ b/packages/api/tests/functional/test_condition_flow.py
@@ -104,7 +104,7 @@ class TestBorrowerListConditions:
         resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 2
+        assert data["pagination"]["total"] == 2
         assert data["data"][0]["description"] == "Verify employment"
         assert data["data"][0]["status"] == "open"
         assert data["data"][1]["response_text"] == "Uploaded both months"
@@ -117,7 +117,7 @@ class TestBorrowerListConditions:
         resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 0
+        assert data["pagination"]["total"] == 0
         assert data["data"] == []
 
     def test_borrower_cannot_see_other_app(self, app, make_client):
@@ -174,7 +174,7 @@ class TestLoanOfficerConditions:
 
         resp = client.get(f"/api/applications/{sarah_app.id}/conditions")
         assert resp.status_code == 200
-        assert resp.json()["count"] == 1
+        assert resp.json()["pagination"]["total"] == 1
 
 
 class TestUnderwriterConditions:

--- a/packages/api/tests/functional/test_cross_persona_isolation.py
+++ b/packages/api/tests/functional/test_cross_persona_isolation.py
@@ -40,32 +40,32 @@ class TestVisibilityCounts:
     def test_borrower_sarah_sees_2(self, make_client):
         client = make_client(borrower_sarah(), make_mock_session(items=sarah_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 2
+        assert resp.json()["pagination"]["total"] == 2
 
     def test_borrower_michael_sees_1(self, make_client):
         client = make_client(borrower_michael(), make_mock_session(items=michael_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 1
+        assert resp.json()["pagination"]["total"] == 1
 
     def test_loan_officer_sees_2_assigned(self, make_client):
         client = make_client(loan_officer(), make_mock_session(items=lo_assigned_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 2
+        assert resp.json()["pagination"]["total"] == 2
 
     def test_underwriter_sees_all_3(self, make_client):
         client = make_client(underwriter(), make_mock_session(items=all_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 3
+        assert resp.json()["pagination"]["total"] == 3
 
     def test_ceo_sees_all_3(self, make_client):
         client = make_client(ceo(), make_mock_session(items=all_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 3
+        assert resp.json()["pagination"]["total"] == 3
 
     def test_admin_sees_all_3(self, make_client):
         client = make_client(admin(), make_mock_session(items=all_applications()))
         resp = client.get("/api/applications/")
-        assert resp.json()["count"] == 3
+        assert resp.json()["pagination"]["total"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -124,20 +124,20 @@ class TestDocumentContentByRole:
     def test_loan_officer_sees_file_path(self, make_client):
         doc = make_document(file_path="/uploads/w2.pdf")
         client = make_client(loan_officer(), make_mock_session(single=doc))
-        data = client.get("/api/documents/1").json()
+        data = client.get("/api/applications/101/documents/1").json()
         assert data["file_path"] == "/uploads/w2.pdf"
 
     def test_underwriter_sees_file_path(self, make_client):
         doc = make_document(file_path="/uploads/w2.pdf")
         client = make_client(underwriter(), make_mock_session(single=doc))
-        data = client.get("/api/documents/1").json()
+        data = client.get("/api/applications/101/documents/1").json()
         assert data["file_path"] == "/uploads/w2.pdf"
 
     def test_ceo_does_not_see_file_path(self, make_client):
         doc = make_document(file_path="/uploads/w2.pdf")
         client = make_client(ceo(), make_mock_session(single=doc))
-        data = client.get("/api/documents/1").json()
-        assert "file_path" not in data
+        data = client.get("/api/applications/101/documents/1").json()
+        assert data["file_path"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/functional/test_loan_officer_flow.py
+++ b/packages/api/tests/functional/test_loan_officer_flow.py
@@ -24,7 +24,7 @@ class TestLoanOfficerVisibility:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 2
+        assert data["pagination"]["total"] == 2
 
     def test_get_assigned_application(self, make_client):
         app = make_app_sarah_1()

--- a/packages/api/tests/functional/test_underwriter_flow.py
+++ b/packages/api/tests/functional/test_underwriter_flow.py
@@ -24,7 +24,7 @@ class TestUnderwriterVisibility:
         resp = client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 3
+        assert data["pagination"]["total"] == 3
 
     def test_get_application_with_pii(self, make_client):
         app = make_app_michael()

--- a/packages/api/tests/integration/test_application_crud.py
+++ b/packages/api/tests/integration/test_application_crud.py
@@ -100,7 +100,7 @@ async def test_list_applications(client_factory, seed_data):
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 3
+    assert data["pagination"]["total"] == 3
     assert len(data["data"]) == 3
     await client.aclose()
 

--- a/packages/api/tests/integration/test_conditions.py
+++ b/packages/api/tests/integration/test_conditions.py
@@ -51,7 +51,7 @@ class TestListConditions:
         resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/conditions")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == 3
+        assert data["pagination"]["total"] == 3
         statuses = {c["status"] for c in data["data"]}
         assert "open" in statuses
         assert "cleared" in statuses
@@ -69,7 +69,7 @@ class TestListConditions:
         assert resp.status_code == 200
         data = resp.json()
         # Only OPEN and RESPONDED statuses, not CLEARED
-        assert data["count"] == 2
+        assert data["pagination"]["total"] == 2
         statuses = {c["status"] for c in data["data"]}
         assert "cleared" not in statuses
         await client.aclose()
@@ -92,7 +92,7 @@ class TestListConditions:
         client = await client_factory(loan_officer())
         resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/conditions")
         assert resp.status_code == 200
-        assert resp.json()["count"] == 3
+        assert resp.json()["pagination"]["total"] == 3
         await client.aclose()
 
 

--- a/packages/api/tests/integration/test_data_scope.py
+++ b/packages/api/tests/integration/test_data_scope.py
@@ -17,7 +17,7 @@ async def test_borrower_sees_only_own_apps(client_factory, seed_data):
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 2
+    assert data["pagination"]["total"] == 2
     assert len(data["data"]) == 2
     await client.aclose()
 
@@ -40,7 +40,7 @@ async def test_lo_sees_only_assigned(client_factory, seed_data):
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 2
+    assert data["pagination"]["total"] == 2
     app_ids = {app["id"] for app in data["data"]}
     assert seed_data.sarah_app1.id in app_ids
     assert seed_data.michael_app.id in app_ids
@@ -55,7 +55,7 @@ async def test_underwriter_sees_all(client_factory, seed_data):
     client = await client_factory(underwriter())
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
-    assert resp.json()["count"] == 3
+    assert resp.json()["pagination"]["total"] == 3
     await client.aclose()
 
 
@@ -66,7 +66,7 @@ async def test_ceo_sees_all(client_factory, seed_data):
     client = await client_factory(ceo())
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
-    assert resp.json()["count"] == 3
+    assert resp.json()["pagination"]["total"] == 3
     await client.aclose()
 
 
@@ -77,7 +77,7 @@ async def test_admin_sees_all(client_factory, seed_data):
     client = await client_factory(admin())
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
-    assert resp.json()["count"] == 3
+    assert resp.json()["pagination"]["total"] == 3
     await client.aclose()
 
 
@@ -99,7 +99,7 @@ async def test_borrower_list_documents_own_app(client_factory, seed_data):
     resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/documents")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 2
+    assert data["pagination"]["total"] == 2
     assert len(data["data"]) == 2
     await client.aclose()
 
@@ -114,7 +114,7 @@ async def test_borrower_cannot_list_other_documents(client_factory, seed_data):
     # Data scope filtering on Documents joins to Application; michael_app is not in
     # Sarah's scope so the query returns 0 docs for that app_id, count=0
     data = resp.json()
-    assert data["count"] == 0
+    assert data["pagination"]["total"] == 0
     await client.aclose()
 
 
@@ -126,5 +126,5 @@ async def test_lo_sees_assigned_app_documents(client_factory, seed_data):
     resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/documents")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 2
+    assert data["pagination"]["total"] == 2
     await client.aclose()

--- a/packages/api/tests/integration/test_documents.py
+++ b/packages/api/tests/integration/test_documents.py
@@ -112,7 +112,7 @@ async def test_list_documents_for_application(client_factory, seed_data):
     resp = await client.get(f"/api/applications/{seed_data.sarah_app1.id}/documents")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 2
+    assert data["pagination"]["total"] == 2
     assert len(data["data"]) == 2
     await client.aclose()
 
@@ -184,6 +184,8 @@ async def test_ceo_blocked_from_document_content(client_factory, seed_data):
     from tests.functional.personas import ceo
 
     client = await client_factory(ceo())
-    resp = await client.get(f"/api/documents/{seed_data.doc1.id}/content")
+    resp = await client.get(
+        f"/api/applications/{seed_data.sarah_app1.id}/documents/{seed_data.doc1.id}/content"
+    )
     assert resp.status_code == 403
     await client.aclose()

--- a/packages/api/tests/integration/test_pagination.py
+++ b/packages/api/tests/integration/test_pagination.py
@@ -15,7 +15,7 @@ async def test_count_matches_data_length(client_factory, seed_data):
         resp = await client.get("/api/applications/")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["count"] == len(data["data"]), (
+        assert data["pagination"]["total"] == len(data["data"]), (
             f"Mismatch for {persona_fn.__name__}: count={data['count']} len={len(data['data'])}"
         )
         await client.aclose()
@@ -30,7 +30,7 @@ async def test_offset_limit(client_factory, seed_data):
     assert resp.status_code == 200
     data = resp.json()
     assert len(data["data"]) == 1
-    assert data["count"] == 3  # Total count is still 3
+    assert data["pagination"]["total"] == 3  # Total count is still 3
     await client.aclose()
 
 
@@ -43,7 +43,7 @@ async def test_coborrower_no_count_inflation(client_factory, seed_data):
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 3
+    assert data["pagination"]["total"] == 3
     await client.aclose()
 
 
@@ -55,7 +55,7 @@ async def test_limit_exceeding_total(client_factory, seed_data):
     resp = await client.get("/api/applications/", params={"limit": 100})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 3
+    assert data["pagination"]["total"] == 3
     assert len(data["data"]) == 3
     await client.aclose()
 
@@ -80,6 +80,6 @@ async def test_zero_results(client_factory, seed_data):
     resp = await client.get("/api/applications/")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["count"] == 0
+    assert data["pagination"]["total"] == 0
     assert data["data"] == []
     await client.aclose()

--- a/packages/api/tests/test_condition.py
+++ b/packages/api/tests/test_condition.py
@@ -68,14 +68,16 @@ def test_condition_item_schema():
 
 
 def test_condition_list_response_schema():
+    from src.schemas import Pagination
+
     resp = ConditionListResponse(
         data=[
             ConditionItem(id=1, description="Verify employment"),
             ConditionItem(id=2, description="Bank statements"),
         ],
-        count=2,
+        pagination=Pagination(total=2, offset=0, limit=20, has_more=False),
     )
-    assert resp.count == 2
+    assert resp.pagination.total == 2
     assert len(resp.data) == 2
 
 

--- a/packages/api/tests/test_documents.py
+++ b/packages/api/tests/test_documents.py
@@ -99,10 +99,10 @@ def test_ceo_get_document_excludes_file_path():
     app = _make_app(ceo, documents=[doc])
     client = TestClient(app)
 
-    response = client.get("/api/documents/1")
+    response = client.get("/api/applications/100/documents/1")
     assert response.status_code == 200
     data = response.json()
-    assert "file_path" not in data
+    assert data["file_path"] is None
     assert data["doc_type"] == DocumentType.W2.value
     assert data["status"] == DocumentStatus.UPLOADED.value
 
@@ -118,7 +118,7 @@ def test_ceo_content_endpoint_returns_403(monkeypatch):
     app = _make_app(ceo, documents=[doc])
     client = TestClient(app)
 
-    response = client.get("/api/documents/1/content")
+    response = client.get("/api/applications/100/documents/1/content")
     assert response.status_code == 403
 
 
@@ -146,7 +146,7 @@ def test_loan_officer_gets_full_document():
     app = _make_app(lo, documents=[doc])
     client = TestClient(app)
 
-    response = client.get("/api/documents/1")
+    response = client.get("/api/applications/100/documents/1")
     assert response.status_code == 200
     data = response.json()
     assert data["file_path"] == "/uploads/paystub.pdf"
@@ -159,7 +159,7 @@ def test_loan_officer_content_endpoint_succeeds():
     app = _make_app(lo, documents=[doc])
     client = TestClient(app)
 
-    response = client.get("/api/documents/1/content")
+    response = client.get("/api/applications/100/documents/1/content")
     assert response.status_code == 200
     assert response.json()["file_path"] == "/uploads/paystub.pdf"
 
@@ -187,7 +187,7 @@ def test_list_documents_returns_metadata_only():
     response = client.get("/api/applications/100/documents")
     assert response.status_code == 200
     data = response.json()
-    assert data["count"] == 3
+    assert data["pagination"]["total"] == 3
     assert len(data["data"]) == 3
     for item in data["data"]:
         assert "file_path" not in item
@@ -204,7 +204,7 @@ def test_get_nonexistent_document_returns_404():
     app = _make_app(admin, documents=[])
     client = TestClient(app)
 
-    response = client.get("/api/documents/999")
+    response = client.get("/api/applications/100/documents/999")
     assert response.status_code == 404
 
 
@@ -214,5 +214,5 @@ def test_content_nonexistent_document_returns_404():
     app = _make_app(admin, documents=[])
     client = TestClient(app)
 
-    response = client.get("/api/documents/999/content")
+    response = client.get("/api/applications/100/documents/999/content")
     assert response.status_code == 404

--- a/packages/api/tests/test_rbac.py
+++ b/packages/api/tests/test_rbac.py
@@ -190,7 +190,7 @@ def test_co_borrower_sees_shared_application(monkeypatch):
     assert resp.status_code == 200
 
     data = resp.json()
-    assert data["count"] == 1
+    assert data["pagination"]["total"] == 1
     apps = data["data"]
     assert len(apps) == 1
     assert apps[0]["id"] == 101


### PR DESCRIPTION
## Summary

Pre-Phase 3 cleanup PR 7: API schema consistency fixes from the consolidated review.

- **S-1**: Codify snake_case as JSON field naming convention in `api-conventions.md`
- **S-2**: Replace per-model `count: int` with shared `Pagination` model (`total`, `offset`, `limit`, `has_more`) on all list responses (applications, conditions, documents)
- **S-5**: Change `str` date fields to `datetime` in admin, rate_lock, and condition schemas (Pydantic handles ISO 8601 parsing automatically)
- **S-6**: Nest document detail + content routes under `/applications/{id}/documents/{id}` for consistent URL hierarchy (was mixed top-level and nested)
- **S-7**: Return single `DocumentDetailResponse` with `file_path=None` for CEO instead of union response type (cleaner OpenAPI spec)

25 files changed across source and tests. All 566 tests passing.

## Test plan

- [x] `AUTH_DISABLED=true pytest -v` -- 566 passed
- [x] `ruff check src/ tests/` -- all checks passed
- [x] Pre-commit hooks (ruff format, ruff check, HMDA isolation) -- passed
- [x] Pagination structure verified across all persona flow tests
- [x] CEO file_path=None behavior verified in unit + functional + integration tests
- [x] Document URL nesting verified with application_id ownership check

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>