### PR TITLE
feat(api): urgency calculation service + pipeline enhancements (F7 PR 1/2)

### DIFF
--- a/packages/api/src/schemas/application.py
+++ b/packages/api/src/schemas/application.py
@@ -8,6 +8,7 @@ from db.enums import ApplicationStage, EmploymentStatus, LoanType
 from pydantic import BaseModel, ConfigDict, Field
 
 from . import Pagination
+from .urgency import UrgencyIndicator
 
 
 class ApplicationCreate(BaseModel):
@@ -60,6 +61,7 @@ class ApplicationResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     borrowers: list[BorrowerSummary] = []
+    urgency: UrgencyIndicator | None = None
 
 
 class ApplicationListResponse(BaseModel):

--- a/packages/api/src/schemas/urgency.py
+++ b/packages/api/src/schemas/urgency.py
@@ -1,0 +1,22 @@
+# This project was developed with assistance from AI tools.
+"""Urgency indicator schemas for pipeline management."""
+
+import enum
+
+from pydantic import BaseModel
+
+
+class UrgencyLevel(str, enum.Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    NORMAL = "normal"
+
+
+class UrgencyIndicator(BaseModel):
+    """Urgency assessment for a single application."""
+
+    level: UrgencyLevel
+    factors: list[str]
+    days_in_stage: int
+    expected_stage_days: int

--- a/packages/api/src/services/urgency.py
+++ b/packages/api/src/services/urgency.py
@@ -1,0 +1,262 @@
+# This project was developed with assistance from AI tools.
+"""Urgency calculation service for loan officer pipeline management.
+
+Batch-computes urgency indicators for applications based on rate lock
+expiry, stage timing, open conditions, and document request age.
+"""
+
+import logging
+from datetime import UTC, datetime
+
+from db import Application, Condition, Document, RateLock
+from db.enums import ApplicationStage, ConditionStatus, DocumentStatus
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..schemas.urgency import UrgencyIndicator, UrgencyLevel
+
+logger = logging.getLogger(__name__)
+
+# Expected days per stage (MVP hardcoded defaults)
+EXPECTED_STAGE_DAYS: dict[ApplicationStage, int] = {
+    ApplicationStage.INQUIRY: 3,
+    ApplicationStage.PREQUALIFICATION: 5,
+    ApplicationStage.APPLICATION: 7,
+    ApplicationStage.PROCESSING: 5,
+    ApplicationStage.UNDERWRITING: 5,
+    ApplicationStage.CONDITIONAL_APPROVAL: 10,
+    ApplicationStage.CLEAR_TO_CLOSE: 7,
+}
+
+# Condition statuses that count as resolved
+_RESOLVED_STATUSES = {ConditionStatus.CLEARED, ConditionStatus.WAIVED}
+
+# Document statuses that represent a pending request (uploaded but not yet reviewed)
+_PENDING_DOC_STATUSES = {
+    DocumentStatus.UPLOADED,
+    DocumentStatus.PROCESSING,
+    DocumentStatus.PENDING_REVIEW,
+}
+
+
+async def compute_urgency(
+    session: AsyncSession,
+    applications: list[Application],
+    *,
+    now: datetime | None = None,
+) -> dict[int, UrgencyIndicator]:
+    """Batch-compute urgency for multiple applications.
+
+    Args:
+        session: Database session.
+        applications: List of Application ORM objects (must have id, stage,
+            updated_at already loaded).
+        now: Override current time (for testing).
+
+    Returns:
+        Mapping of application_id to UrgencyIndicator.
+    """
+    if not applications:
+        return {}
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    app_ids = [app.id for app in applications]
+
+    # Batch queries
+    rate_locks = await _batch_active_rate_locks(session, app_ids)
+    open_condition_counts = await _batch_open_condition_counts(session, app_ids)
+    oldest_pending_docs = await _batch_oldest_pending_docs(session, app_ids)
+
+    result: dict[int, UrgencyIndicator] = {}
+    for app in applications:
+        factors: list[str] = []
+        levels: list[UrgencyLevel] = []
+
+        # Factor 1: Rate lock expiry
+        lock = rate_locks.get(app.id)
+        if lock:
+            _assess_rate_lock(lock, now, levels, factors)
+
+        # Factor 2: Stage timing
+        stage = app.stage or ApplicationStage.INQUIRY
+        expected = EXPECTED_STAGE_DAYS.get(stage)
+        updated_at = _ensure_tz(app.updated_at)
+        days_in_stage = max((now - updated_at).days, 0)
+
+        if expected:
+            _assess_stage_timing(days_in_stage, expected, stage, levels, factors)
+        else:
+            expected = 0
+
+        # Factor 3: Open conditions
+        open_count = open_condition_counts.get(app.id, 0)
+        if open_count > 0 and lock:
+            _assess_conditions_with_lock(open_count, lock, now, levels, factors)
+
+        # Factor 4: Pending document age
+        oldest_doc_created = oldest_pending_docs.get(app.id)
+        if oldest_doc_created:
+            _assess_pending_docs(oldest_doc_created, now, levels, factors)
+
+        level = min(levels) if levels else UrgencyLevel.NORMAL
+
+        result[app.id] = UrgencyIndicator(
+            level=level,
+            factors=factors,
+            days_in_stage=days_in_stage,
+            expected_stage_days=expected or 0,
+        )
+
+    return result
+
+
+def _ensure_tz(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware (UTC)."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _assess_rate_lock(
+    lock: RateLock,
+    now: datetime,
+    levels: list[UrgencyLevel],
+    factors: list[str],
+) -> None:
+    """Assess urgency from rate lock expiry."""
+    expiration = _ensure_tz(lock.expiration_date)
+    days_remaining = (expiration - now).days
+
+    if days_remaining <= 3:
+        levels.append(UrgencyLevel.CRITICAL)
+        factors.append(f"Rate lock expires in {max(days_remaining, 0)} days")
+    elif days_remaining <= 7:
+        levels.append(UrgencyLevel.HIGH)
+        factors.append(f"Rate lock expires in {days_remaining} days")
+
+
+def _assess_stage_timing(
+    days_in_stage: int,
+    expected: int,
+    stage: ApplicationStage,
+    levels: list[UrgencyLevel],
+    factors: list[str],
+) -> None:
+    """Assess urgency from time in current stage."""
+    overdue = days_in_stage - expected
+    label = stage.value.replace("_", " ").title()
+
+    if overdue >= 7:
+        levels.append(UrgencyLevel.CRITICAL)
+        factors.append(f"{label} stage overdue by {overdue} days")
+    elif overdue >= 4:
+        levels.append(UrgencyLevel.HIGH)
+        factors.append(f"{label} stage overdue by {overdue} days")
+    elif days_in_stage >= int(expected * 0.8):
+        levels.append(UrgencyLevel.MEDIUM)
+        factors.append(f"{label} stage at {days_in_stage}/{expected} expected days")
+
+
+def _assess_conditions_with_lock(
+    open_count: int,
+    lock: RateLock,
+    now: datetime,
+    levels: list[UrgencyLevel],
+    factors: list[str],
+) -> None:
+    """Assess urgency from open conditions combined with rate lock deadline."""
+    expiration = _ensure_tz(lock.expiration_date)
+    days_remaining = (expiration - now).days
+
+    if open_count > 0 and days_remaining <= 5:
+        levels.append(UrgencyLevel.CRITICAL)
+        factors.append(
+            f"{open_count} open condition(s) with rate lock expiring in "
+            f"{max(days_remaining, 0)} days"
+        )
+
+
+def _assess_pending_docs(
+    oldest_created: datetime,
+    now: datetime,
+    levels: list[UrgencyLevel],
+    factors: list[str],
+) -> None:
+    """Assess urgency from age of pending document requests."""
+    oldest_created = _ensure_tz(oldest_created)
+    hours_pending = (now - oldest_created).total_seconds() / 3600
+
+    if hours_pending >= 48:
+        levels.append(UrgencyLevel.HIGH)
+        factors.append(f"Document request pending for {int(hours_pending)} hours")
+
+
+# ---------------------------------------------------------------------------
+# Batch query helpers
+# ---------------------------------------------------------------------------
+
+
+async def _batch_active_rate_locks(
+    session: AsyncSession,
+    app_ids: list[int],
+) -> dict[int, RateLock]:
+    """Return the most recent active rate lock per application."""
+    stmt = (
+        select(RateLock)
+        .where(
+            RateLock.application_id.in_(app_ids),
+            RateLock.is_active.is_(True),
+        )
+        .order_by(RateLock.created_at.desc())
+    )
+    result = await session.execute(stmt)
+    locks = result.scalars().all()
+
+    # Keep only the most recent per app
+    by_app: dict[int, RateLock] = {}
+    for lock in locks:
+        if lock.application_id not in by_app:
+            by_app[lock.application_id] = lock
+    return by_app
+
+
+async def _batch_open_condition_counts(
+    session: AsyncSession,
+    app_ids: list[int],
+) -> dict[int, int]:
+    """Return count of open (unresolved) conditions per application."""
+    stmt = (
+        select(
+            Condition.application_id,
+            func.count().label("cnt"),
+        )
+        .where(
+            Condition.application_id.in_(app_ids),
+            Condition.status.notin_([s.value for s in _RESOLVED_STATUSES]),
+        )
+        .group_by(Condition.application_id)
+    )
+    result = await session.execute(stmt)
+    return {row.application_id: row.cnt for row in result}
+
+
+async def _batch_oldest_pending_docs(
+    session: AsyncSession,
+    app_ids: list[int],
+) -> dict[int, datetime]:
+    """Return the oldest pending document created_at per application."""
+    stmt = (
+        select(
+            Document.application_id,
+            func.min(Document.created_at).label("oldest"),
+        )
+        .where(
+            Document.application_id.in_(app_ids),
+            Document.status.in_([s.value for s in _PENDING_DOC_STATUSES]),
+        )
+        .group_by(Document.application_id)
+    )
+    result = await session.execute(stmt)
+    return {row.application_id: row.oldest for row in result}

--- a/packages/api/tests/functional/data_factory.py
+++ b/packages/api/tests/functional/data_factory.py
@@ -71,52 +71,66 @@ def _make_app_borrower(borrower, *, is_primary=True) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
+def _make_application(**fields) -> MagicMock:
+    """Build a mock Application with defaults for schema-required attributes.
+
+    Ensures Pydantic ``from_attributes`` validation succeeds by setting
+    attributes that don't exist on the real ORM model to ``None``.
+    """
+    app = MagicMock()
+    for key, value in fields.items():
+        setattr(app, key, value)
+    # Schema-only fields that the ORM model doesn't carry
+    app.urgency = None
+    return app
+
+
 def make_app_sarah_1() -> MagicMock:
     """App 101: Sarah, APPLICATION stage, assigned to LO."""
-    app = MagicMock()
-    app.id = 101
-    app.stage = ApplicationStage.APPLICATION
-    app.loan_type = LoanType.CONVENTIONAL_30
-    app.property_address = "123 Oak Street"
-    app.loan_amount = Decimal("350000.00")
-    app.property_value = Decimal("450000.00")
-    app.assigned_to = LO_USER_ID
-    app.created_at = datetime(2026, 1, 10, tzinfo=UTC)
-    app.updated_at = datetime(2026, 1, 15, tzinfo=UTC)
-    app.application_borrowers = [_make_app_borrower(make_borrower_sarah())]
-    return app
+    return _make_application(
+        id=101,
+        stage=ApplicationStage.APPLICATION,
+        loan_type=LoanType.CONVENTIONAL_30,
+        property_address="123 Oak Street",
+        loan_amount=Decimal("350000.00"),
+        property_value=Decimal("450000.00"),
+        assigned_to=LO_USER_ID,
+        created_at=datetime(2026, 1, 10, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 15, tzinfo=UTC),
+        application_borrowers=[_make_app_borrower(make_borrower_sarah())],
+    )
 
 
 def make_app_sarah_2() -> MagicMock:
     """App 102: Sarah, INQUIRY stage, unassigned."""
-    app = MagicMock()
-    app.id = 102
-    app.stage = ApplicationStage.INQUIRY
-    app.loan_type = None
-    app.property_address = None
-    app.loan_amount = None
-    app.property_value = None
-    app.assigned_to = None
-    app.created_at = datetime(2026, 2, 1, tzinfo=UTC)
-    app.updated_at = datetime(2026, 2, 1, tzinfo=UTC)
-    app.application_borrowers = [_make_app_borrower(make_borrower_sarah())]
-    return app
+    return _make_application(
+        id=102,
+        stage=ApplicationStage.INQUIRY,
+        loan_type=None,
+        property_address=None,
+        loan_amount=None,
+        property_value=None,
+        assigned_to=None,
+        created_at=datetime(2026, 2, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 2, 1, tzinfo=UTC),
+        application_borrowers=[_make_app_borrower(make_borrower_sarah())],
+    )
 
 
 def make_app_michael() -> MagicMock:
     """App 103: Michael, UNDERWRITING stage, assigned to LO."""
-    app = MagicMock()
-    app.id = 103
-    app.stage = ApplicationStage.UNDERWRITING
-    app.loan_type = LoanType.FHA
-    app.property_address = "456 Maple Avenue"
-    app.loan_amount = Decimal("275000.00")
-    app.property_value = Decimal("320000.00")
-    app.assigned_to = LO_USER_ID
-    app.created_at = datetime(2026, 1, 20, tzinfo=UTC)
-    app.updated_at = datetime(2026, 2, 10, tzinfo=UTC)
-    app.application_borrowers = [_make_app_borrower(make_borrower_michael())]
-    return app
+    return _make_application(
+        id=103,
+        stage=ApplicationStage.UNDERWRITING,
+        loan_type=LoanType.FHA,
+        property_address="456 Maple Avenue",
+        loan_amount=Decimal("275000.00"),
+        property_value=Decimal("320000.00"),
+        assigned_to=LO_USER_ID,
+        created_at=datetime(2026, 1, 20, tzinfo=UTC),
+        updated_at=datetime(2026, 2, 10, tzinfo=UTC),
+        application_borrowers=[_make_app_borrower(make_borrower_michael())],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/api/tests/functional/test_loan_officer_flow.py
+++ b/packages/api/tests/functional/test_loan_officer_flow.py
@@ -2,23 +2,47 @@
 """Functional tests: Loan Officer persona journey.
 
 Loan officers see only applications assigned to them. They can update
-applications. Unassigned apps return 404.
+applications. Unassigned apps return 404. Pipeline views include urgency
+metadata with sorting and filtering.
 """
+
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.schemas.urgency import UrgencyIndicator, UrgencyLevel
+
 from .data_factory import lo_assigned_applications, make_app_sarah_1
 from .mock_db import make_mock_session
-from .personas import loan_officer
+from .personas import borrower_sarah, loan_officer
 
 pytestmark = pytest.mark.functional
+
+# Reusable urgency indicators for patching
+_URGENCY_CRITICAL = UrgencyIndicator(
+    level=UrgencyLevel.CRITICAL,
+    factors=["Rate lock expires in 2 days"],
+    days_in_stage=5,
+    expected_stage_days=7,
+)
+_URGENCY_NORMAL = UrgencyIndicator(
+    level=UrgencyLevel.NORMAL,
+    factors=[],
+    days_in_stage=1,
+    expected_stage_days=5,
+)
 
 
 class TestLoanOfficerVisibility:
     """LO sees assigned apps only (101 + 103, not 102 which is unassigned)."""
 
-    def test_list_assigned_applications(self, make_client):
+    @patch("src.routes.applications.compute_urgency", new_callable=AsyncMock)
+    def test_list_assigned_applications(self, mock_urgency, make_client):
         apps = lo_assigned_applications()
+        mock_urgency.return_value = {
+            101: _URGENCY_CRITICAL,
+            103: _URGENCY_NORMAL,
+        }
         client = make_client(loan_officer(), make_mock_session(items=apps))
 
         resp = client.get("/api/applications/")
@@ -70,3 +94,84 @@ class TestLoanOfficerCanUpdate:
             },
         )
         assert resp.status_code == 404
+
+
+class TestLoanOfficerPipeline:
+    """Pipeline enhancements: urgency metadata, sorting, filtering."""
+
+    @patch("src.routes.applications.compute_urgency", new_callable=AsyncMock)
+    def test_lo_gets_urgency_in_list_response(self, mock_urgency, make_client):
+        """LO list response includes urgency indicators."""
+        apps = lo_assigned_applications()
+        mock_urgency.return_value = {
+            101: _URGENCY_CRITICAL,
+            103: _URGENCY_NORMAL,
+        }
+        client = make_client(loan_officer(), make_mock_session(items=apps))
+
+        resp = client.get("/api/applications/")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Both items should have urgency
+        for item in data["data"]:
+            assert item["urgency"] is not None
+            assert "level" in item["urgency"]
+            assert "factors" in item["urgency"]
+
+    @patch("src.routes.applications.compute_urgency", new_callable=AsyncMock)
+    def test_sort_by_urgency_critical_first(self, mock_urgency, make_client):
+        """Sorting by urgency puts Critical apps first."""
+        apps = lo_assigned_applications()
+        mock_urgency.return_value = {
+            101: _URGENCY_CRITICAL,
+            103: _URGENCY_NORMAL,
+        }
+        client = make_client(loan_officer(), make_mock_session(items=apps))
+
+        resp = client.get("/api/applications/?sort_by=urgency")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        levels = [item["urgency"]["level"] for item in data["data"]]
+        assert levels[0] == "critical"
+
+    @patch("src.routes.applications.compute_urgency", new_callable=AsyncMock)
+    def test_filter_by_stage(self, mock_urgency, make_client):
+        """filter_stage query param is accepted."""
+        apps = lo_assigned_applications()
+        mock_urgency.return_value = {
+            101: _URGENCY_NORMAL,
+            103: _URGENCY_NORMAL,
+        }
+        client = make_client(loan_officer(), make_mock_session(items=apps))
+
+        resp = client.get("/api/applications/?filter_stage=application")
+        assert resp.status_code == 200
+
+    @patch("src.routes.applications.compute_urgency", new_callable=AsyncMock)
+    def test_filter_stalled(self, mock_urgency, make_client):
+        """filter_stalled query param is accepted."""
+        apps = lo_assigned_applications()
+        mock_urgency.return_value = {
+            101: _URGENCY_NORMAL,
+            103: _URGENCY_NORMAL,
+        }
+        client = make_client(loan_officer(), make_mock_session(items=apps))
+
+        resp = client.get("/api/applications/?filter_stalled=true")
+        assert resp.status_code == 200
+
+    def test_borrower_does_not_get_urgency(self, make_client):
+        """Non-LO roles get null urgency."""
+        from .data_factory import sarah_applications
+
+        apps = sarah_applications()
+        client = make_client(borrower_sarah(), make_mock_session(items=apps))
+
+        resp = client.get("/api/applications/")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        for item in data["data"]:
+            assert item["urgency"] is None

--- a/packages/api/tests/test_urgency.py
+++ b/packages/api/tests/test_urgency.py
@@ -1,0 +1,336 @@
+# This project was developed with assistance from AI tools.
+"""Tests for urgency calculation service."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.schemas.urgency import UrgencyIndicator, UrgencyLevel
+from src.services.urgency import EXPECTED_STAGE_DAYS, compute_urgency
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 3, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _mock_app(
+    app_id=101,
+    stage="application",
+    updated_at=None,
+):
+    """Build a mock Application ORM object."""
+    from db.enums import ApplicationStage
+
+    app = MagicMock()
+    app.id = app_id
+    app.stage = ApplicationStage(stage)
+    app.updated_at = updated_at or NOW
+    return app
+
+
+def _mock_rate_lock(app_id=101, expiration_days=30, is_active=True):
+    """Build a mock RateLock ORM object."""
+    rl = MagicMock()
+    rl.application_id = app_id
+    rl.expiration_date = NOW + timedelta(days=expiration_days)
+    rl.is_active = is_active
+    rl.created_at = NOW - timedelta(days=10)
+    return rl
+
+
+def _mock_session(rate_locks=None, condition_rows=None, doc_rows=None):
+    """Build an AsyncMock session with side_effect for 3 batch queries.
+
+    The urgency service runs 3 sequential queries:
+    1. Rate locks (scalars().all())
+    2. Condition counts (rows with application_id + cnt)
+    3. Oldest pending docs (rows with application_id + oldest)
+    """
+    session = AsyncMock()
+
+    # Result 1: rate locks
+    rl_result = MagicMock()
+    rl_result.scalars.return_value.all.return_value = rate_locks or []
+
+    # Result 2: condition counts
+    cond_result = MagicMock()
+    cond_result.__iter__ = MagicMock(return_value=iter(condition_rows or []))
+
+    # Result 3: oldest pending docs
+    doc_result = MagicMock()
+    doc_result.__iter__ = MagicMock(return_value=iter(doc_rows or []))
+
+    session.execute = AsyncMock(side_effect=[rl_result, cond_result, doc_result])
+    return session
+
+
+def _cond_row(app_id, cnt):
+    """Mock a row from the condition count query."""
+    row = MagicMock()
+    row.application_id = app_id
+    row.cnt = cnt
+    return row
+
+
+def _doc_row(app_id, oldest):
+    """Mock a row from the oldest pending doc query."""
+    row = MagicMock()
+    row.application_id = app_id
+    row.oldest = oldest
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Rate lock urgency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_lock_expiring_in_2_days_is_critical():
+    app = _mock_app()
+    rl = _mock_rate_lock(expiration_days=2)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.CRITICAL
+    assert any("Rate lock expires" in f for f in result[101].factors)
+
+
+@pytest.mark.asyncio
+async def test_rate_lock_expiring_in_5_days_is_high():
+    app = _mock_app()
+    rl = _mock_rate_lock(expiration_days=5)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.HIGH
+    assert any("Rate lock expires" in f for f in result[101].factors)
+
+
+@pytest.mark.asyncio
+async def test_rate_lock_expiring_in_3_days_is_critical():
+    app = _mock_app()
+    rl = _mock_rate_lock(expiration_days=3)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.CRITICAL
+
+
+@pytest.mark.asyncio
+async def test_rate_lock_expiring_in_10_days_no_urgency():
+    app = _mock_app()
+    rl = _mock_rate_lock(expiration_days=10)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    # No rate lock factor, but stage timing may contribute
+    assert not any("Rate lock" in f for f in result[101].factors)
+
+
+# ---------------------------------------------------------------------------
+# Stage timing urgency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stage_overdue_by_8_days_is_critical():
+    expected = EXPECTED_STAGE_DAYS.get("application", 7)
+    updated_at = NOW - timedelta(days=expected + 8)
+    app = _mock_app(updated_at=updated_at)
+    session = _mock_session()
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.CRITICAL
+    assert any("overdue" in f for f in result[101].factors)
+
+
+@pytest.mark.asyncio
+async def test_stage_overdue_by_5_days_is_high():
+    expected = EXPECTED_STAGE_DAYS.get("application", 7)
+    updated_at = NOW - timedelta(days=expected + 5)
+    app = _mock_app(updated_at=updated_at)
+    session = _mock_session()
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.HIGH
+    assert any("overdue" in f for f in result[101].factors)
+
+
+@pytest.mark.asyncio
+async def test_stage_at_80_percent_is_medium():
+    """Stage at exactly 80% of expected days -> MEDIUM."""
+    # Processing has 5 expected days; 80% = 4 days
+    updated_at = NOW - timedelta(days=4)
+    app = _mock_app(stage="processing", updated_at=updated_at)
+    session = _mock_session()
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.MEDIUM
+    assert any("expected days" in f for f in result[101].factors)
+
+
+# ---------------------------------------------------------------------------
+# Multiple factors -- highest wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multiple_factors_highest_wins():
+    """Rate lock Critical + stage Medium -> overall Critical."""
+    updated_at = NOW - timedelta(days=4)  # 80% of processing (5 days)
+    app = _mock_app(stage="processing", updated_at=updated_at)
+    rl = _mock_rate_lock(expiration_days=2)  # Critical
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.CRITICAL
+    assert len(result[101].factors) >= 2
+
+
+# ---------------------------------------------------------------------------
+# No factors -> Normal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_factors_returns_normal():
+    app = _mock_app(updated_at=NOW)  # Just entered stage
+    session = _mock_session()
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.NORMAL
+    assert result[101].factors == []
+
+
+# ---------------------------------------------------------------------------
+# Pending documents
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_doc_over_48_hours_is_high():
+    app = _mock_app(updated_at=NOW)
+    oldest = NOW - timedelta(hours=72)
+    session = _mock_session(doc_rows=[_doc_row(101, oldest)])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.HIGH
+    assert any("Document request pending" in f for f in result[101].factors)
+
+
+@pytest.mark.asyncio
+async def test_pending_doc_under_48_hours_no_factor():
+    app = _mock_app(updated_at=NOW)
+    oldest = NOW - timedelta(hours=24)
+    session = _mock_session(doc_rows=[_doc_row(101, oldest)])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert not any("Document request" in f for f in result[101].factors)
+
+
+# ---------------------------------------------------------------------------
+# Open conditions with rate lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_conditions_with_closing_lock_is_critical():
+    app = _mock_app(updated_at=NOW)
+    rl = _mock_rate_lock(expiration_days=4)
+    session = _mock_session(
+        rate_locks=[rl],
+        condition_rows=[_cond_row(101, 3)],
+    )
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    assert result[101].level == UrgencyLevel.CRITICAL
+    assert any("open condition" in f for f in result[101].factors)
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_applications_returns_empty_dict():
+    session = AsyncMock()
+    result = await compute_urgency(session, [], now=NOW)
+    assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Batch: multiple applications
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_batch_computes_per_application():
+    app_a = _mock_app(app_id=1, updated_at=NOW)
+    app_b = _mock_app(app_id=2, updated_at=NOW - timedelta(days=20))
+
+    rl = _mock_rate_lock(app_id=1, expiration_days=2)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app_a, app_b], now=NOW)
+
+    assert result[1].level == UrgencyLevel.CRITICAL  # rate lock
+    assert result[2].level == UrgencyLevel.CRITICAL  # stage overdue
+
+
+# ---------------------------------------------------------------------------
+# Factors list contains human-readable strings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_factors_are_human_readable():
+    app = _mock_app(updated_at=NOW - timedelta(days=20))
+    rl = _mock_rate_lock(expiration_days=2)
+    session = _mock_session(rate_locks=[rl])
+
+    result = await compute_urgency(session, [app], now=NOW)
+
+    for factor in result[101].factors:
+        assert isinstance(factor, str)
+        assert len(factor) > 10  # Non-trivial description
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_urgency_indicator_schema():
+    indicator = UrgencyIndicator(
+        level=UrgencyLevel.HIGH,
+        factors=["Rate lock expires in 5 days"],
+        days_in_stage=3,
+        expected_stage_days=7,
+    )
+    assert indicator.level == UrgencyLevel.HIGH
+    assert len(indicator.factors) == 1
+    assert indicator.days_in_stage == 3
+
+
+def test_urgency_level_values():
+    assert UrgencyLevel.CRITICAL.value == "critical"
+    assert UrgencyLevel.HIGH.value == "high"
+    assert UrgencyLevel.MEDIUM.value == "medium"
+    assert UrgencyLevel.NORMAL.value == "normal"


### PR DESCRIPTION
## Summary

- Urgency calculation service computing per-application urgency from rate lock expiry, stage timing, open conditions, and pending document age
- Pipeline list endpoint enhanced with `sort_by` (urgency/updated_at/loan_amount), `filter_stage`, and `filter_stalled` query parameters
- LO/admin roles receive urgency metadata (`UrgencyIndicator`) in list responses; other roles get null
- Batch-optimized: 3 queries regardless of result count (rate locks, conditions, docs)

**Stories:** S-3-F7-01 (pipeline with urgency), S-3-F7-03 (urgency calculation logic)

## Changes

| File | Action |
|------|--------|
| `src/schemas/urgency.py` | New: `UrgencyLevel` enum + `UrgencyIndicator` model |
| `src/services/urgency.py` | New: batch urgency computation with 4 factor assessors |
| `src/schemas/application.py` | Add optional `urgency` field to `ApplicationResponse` |
| `src/services/application.py` | Add `filter_stage`, `filter_stalled`, `sort_by` params |
| `src/routes/applications.py` | Wire urgency enrichment + new query params to list endpoint |
| `tests/test_urgency.py` | 17 unit tests for urgency calculation |
| `tests/functional/test_loan_officer_flow.py` | 5 pipeline functional tests |
| `tests/functional/data_factory.py` | Defensive mock factory for schema-only fields |

## Test plan

- [x] 17 urgency unit tests (rate lock, stage timing, conditions, docs, batch, schema)
- [x] 5 LO pipeline functional tests (urgency in response, sort by urgency, filter by stage, filter stalled, borrower gets null)
- [x] Full suite: 588 passed, 0 failed
- [x] Lint clean (`ruff check src/`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>