### PR TITLE
feat(api): add kb_search tool + conflict detection (F10 PR 2/2)

### DIFF
--- a/config/agents/loan-officer-assistant.yaml
+++ b/config/agents/loan-officer-assistant.yaml
@@ -19,6 +19,7 @@ system_prompt: |
   - Submit an application to underwriting using the lo_submit_to_underwriting tool
   - Look up mortgage product information using the product_info tool
   - Run affordability estimates using the affordability_calc tool
+  - Search the compliance knowledge base for regulatory guidance using the kb_search tool
 
   RBAC RULES:
   - You can only access applications assigned to the authenticated loan officer.
@@ -120,6 +121,9 @@ tools:
   - name: affordability_calc
     description: "Calculate affordability estimate given income, debts, and down payment"
     allowed_roles: [borrower, loan_officer, underwriter, ceo, admin]
+  - name: kb_search
+    description: "Search the compliance knowledge base for regulatory guidance"
+    allowed_roles: [loan_officer, underwriter, admin]
 
 model_routing:
   strategy: per_query

--- a/packages/api/src/agents/compliance_tools.py
+++ b/packages/api/src/agents/compliance_tools.py
@@ -1,0 +1,121 @@
+# This project was developed with assistance from AI tools.
+"""LangGraph tools for compliance knowledge base search.
+
+Provides the kb_search tool that agents can use to query the three-tier
+compliance knowledge base (federal regulations, agency guidelines,
+internal policies) with conflict detection and audit logging.
+
+Design note -- session-per-tool-call:
+    Each tool opens its own ``SessionLocal()`` context rather than sharing
+    a single session across the agent turn.  See loan_officer_tools.py
+    for rationale.
+"""
+
+import logging
+from typing import Annotated
+
+from db.database import SessionLocal
+from langchain_core.tools import tool
+from langgraph.prebuilt import InjectedState
+
+from ..services.audit import write_audit_event
+from ..services.compliance.knowledge_base.conflict import detect_conflicts
+from ..services.compliance.knowledge_base.search import search_kb
+
+logger = logging.getLogger(__name__)
+
+_TIER_LABELS = {1: "Federal Regulation", 2: "Agency Guideline", 3: "Internal Policy"}
+
+_DISCLAIMER = (
+    "\nThis content is simulated for demonstration purposes "
+    "and does not constitute legal or regulatory advice."
+)
+
+
+@tool
+async def kb_search(
+    query: str,
+    state: Annotated[dict, InjectedState],
+) -> str:
+    """Search the Summit Cap Financial compliance knowledge base for regulatory guidance.
+
+    Searches federal regulations, agency guidelines, and internal policies
+    using semantic similarity. Returns results ranked by relevance with
+    tier-based priority (federal > agency > internal). Detects conflicts
+    between sources automatically.
+
+    Args:
+        query: The regulatory or compliance question to search for.
+        state: Injected agent state containing user context.
+    """
+    user_id = state.get("user_id", "anonymous")
+    user_role = state.get("user_role", "")
+    session_id = state.get("session_id")
+
+    async with SessionLocal() as session:
+        # Search the KB
+        results = await search_kb(session, query)
+
+        # Audit the search
+        await write_audit_event(
+            session,
+            event_type="tool_call",
+            session_id=session_id,
+            user_id=user_id,
+            user_role=user_role,
+            event_data={
+                "tool": "kb_search",
+                "query": query,
+                "result_count": len(results),
+            },
+        )
+
+        if not results:
+            await session.commit()
+            return (
+                "No relevant compliance guidance found for that query. "
+                "Could you rephrase your question or be more specific?" + _DISCLAIMER
+            )
+
+        # Detect conflicts
+        conflicts = detect_conflicts(results)
+
+        if conflicts:
+            await write_audit_event(
+                session,
+                event_type="system",
+                session_id=session_id,
+                user_id=user_id,
+                user_role=user_role,
+                event_data={
+                    "action": "kb_conflict_detected",
+                    "query": query,
+                    "conflict_count": len(conflicts),
+                    "conflict_types": [c.conflict_type for c in conflicts],
+                },
+            )
+
+        await session.commit()
+
+    # Format output
+    lines = [f"Compliance KB Search Results ({len(results)} found):\n"]
+
+    for i, r in enumerate(results, 1):
+        lines.append(f"{i}. [{r.tier_label}]")
+        lines.append(f"   Source: {r.source_document}")
+        if r.section_ref:
+            lines.append(f"   Section: {r.section_ref}")
+        if r.effective_date:
+            lines.append(f"   Effective: {r.effective_date}")
+        lines.append(f"   {r.chunk_text[:500]}")
+        lines.append("")
+
+    if conflicts:
+        lines.append("CONFLICTS DETECTED:")
+        for c in conflicts:
+            lines.append(f"  - {c.conflict_type.replace('_', ' ').title()}: {c.description}")
+        lines.append("")
+
+    lines.append(_DISCLAIMER)
+
+    return "\n".join(lines)

--- a/packages/api/src/agents/loan_officer_assistant.py
+++ b/packages/api/src/agents/loan_officer_assistant.py
@@ -4,12 +4,13 @@
 Tools: lo_application_detail, lo_document_review, lo_document_quality,
 lo_completeness_check, lo_mark_resubmission, lo_underwriting_readiness,
 lo_submit_to_underwriting, lo_draft_communication, lo_send_communication,
-product_info, affordability_calc.
+product_info, affordability_calc, kb_search.
 """
 
 from typing import Any
 
 from .base import build_agent_graph
+from .compliance_tools import kb_search
 from .loan_officer_tools import (
     lo_application_detail,
     lo_completeness_check,
@@ -40,6 +41,7 @@ def build_graph(config: dict[str, Any], checkpointer=None):
             lo_submit_to_underwriting,
             lo_draft_communication,
             lo_send_communication,
+            kb_search,
         ],
         checkpointer=checkpointer,
     )

--- a/packages/api/src/services/compliance/knowledge_base/conflict.py
+++ b/packages/api/src/services/compliance/knowledge_base/conflict.py
@@ -1,0 +1,131 @@
+# This project was developed with assistance from AI tools.
+"""Compliance KB conflict detection.
+
+Pattern-based MVP heuristics for detecting conflicting guidance across
+KB search results from different tiers (federal, agency, internal).
+"""
+
+import re
+from dataclasses import dataclass
+
+from .search import KBSearchResult
+
+_PERCENTAGE_PATTERN = re.compile(r"\b(\d+(?:\.\d+)?)\s*%")
+_MUST_PATTERN = re.compile(
+    r"\b(must not|must|required|prohibited|shall not|shall)\b", re.IGNORECASE
+)
+
+
+@dataclass
+class Conflict:
+    """A detected conflict between two KB search results."""
+
+    result_a: KBSearchResult
+    result_b: KBSearchResult
+    conflict_type: str  # "numeric_threshold" | "contradictory_directive" | "same_tier"
+    description: str
+
+
+def _extract_percentages(text: str) -> list[float]:
+    """Extract percentage values from text."""
+    return [float(m.group(1)) for m in _PERCENTAGE_PATTERN.finditer(text)]
+
+
+def _extract_directives(text: str) -> set[str]:
+    """Extract regulatory directive keywords from text."""
+    return {m.group(1).lower() for m in _MUST_PATTERN.finditer(text)}
+
+
+def _is_contradictory_pair(directives_a: set[str], directives_b: set[str]) -> bool:
+    """Check if two sets of directives contain contradictory pairs."""
+    positive = {"must", "required", "shall"}
+    negative = {"must not", "prohibited", "shall not"}
+    has_positive_a = bool(directives_a & positive)
+    has_negative_a = bool(directives_a & negative)
+    has_positive_b = bool(directives_b & positive)
+    has_negative_b = bool(directives_b & negative)
+    return (has_positive_a and has_negative_b) or (has_negative_a and has_positive_b)
+
+
+def detect_conflicts(results: list[KBSearchResult]) -> list[Conflict]:
+    """Detect conflicts between KB search results.
+
+    Detection rules:
+    1. Numeric thresholds: different percentages across different tiers
+    2. Contradictory directives: "must" vs "must not" across results
+    3. Same-tier divergence: two results from the same tier with different values
+
+    Args:
+        results: List of KB search results to check for conflicts.
+
+    Returns:
+        List of detected conflicts.
+    """
+    if len(results) < 2:
+        return []
+
+    conflicts: list[Conflict] = []
+    seen_pairs: set[tuple[int, int]] = set()
+
+    for i, a in enumerate(results):
+        for j, b in enumerate(results):
+            if i >= j:
+                continue
+
+            pair_key = (i, j)
+            if pair_key in seen_pairs:
+                continue
+            seen_pairs.add(pair_key)
+
+            pcts_a = _extract_percentages(a.chunk_text)
+            pcts_b = _extract_percentages(b.chunk_text)
+
+            # Rule 1: Numeric threshold conflicts across tiers
+            if pcts_a and pcts_b and a.tier != b.tier:
+                diff_pcts = set(pcts_a) - set(pcts_b)
+                if diff_pcts:
+                    conflicts.append(
+                        Conflict(
+                            result_a=a,
+                            result_b=b,
+                            conflict_type="numeric_threshold",
+                            description=(
+                                f"{a.tier_label} cites {pcts_a[0]}% while "
+                                f"{b.tier_label} cites {pcts_b[0]}%"
+                            ),
+                        )
+                    )
+                    continue
+
+            # Rule 2: Contradictory directives
+            dirs_a = _extract_directives(a.chunk_text)
+            dirs_b = _extract_directives(b.chunk_text)
+            if dirs_a and dirs_b and _is_contradictory_pair(dirs_a, dirs_b):
+                conflicts.append(
+                    Conflict(
+                        result_a=a,
+                        result_b=b,
+                        conflict_type="contradictory_directive",
+                        description=(
+                            f"{a.tier_label} and {b.tier_label} contain contradictory directives"
+                        ),
+                    )
+                )
+                continue
+
+            # Rule 3: Same-tier divergence with different percentages
+            if pcts_a and pcts_b and a.tier == b.tier:
+                if set(pcts_a) != set(pcts_b):
+                    conflicts.append(
+                        Conflict(
+                            result_a=a,
+                            result_b=b,
+                            conflict_type="same_tier",
+                            description=(
+                                f"Two {a.tier_label} sources cite different values: "
+                                f"{pcts_a[0]}% vs {pcts_b[0]}%"
+                            ),
+                        )
+                    )
+
+    return conflicts

--- a/packages/api/tests/test_kb_conflict.py
+++ b/packages/api/tests/test_kb_conflict.py
@@ -1,0 +1,110 @@
+# This project was developed with assistance from AI tools.
+"""Tests for compliance KB conflict detection."""
+
+from src.services.compliance.knowledge_base.conflict import detect_conflicts
+from src.services.compliance.knowledge_base.search import KBSearchResult
+
+
+def _make_result(
+    chunk_text: str,
+    tier: int,
+    source: str = "Test Doc",
+    section: str | None = None,
+) -> KBSearchResult:
+    """Create a KBSearchResult for testing."""
+    tier_labels = {1: "Federal Regulation", 2: "Agency Guideline", 3: "Internal Policy"}
+    return KBSearchResult(
+        chunk_text=chunk_text,
+        source_document=source,
+        section_ref=section,
+        tier=tier,
+        tier_label=tier_labels.get(tier, f"Tier {tier}"),
+        similarity=0.8,
+        boosted_similarity=0.8,
+        effective_date=None,
+    )
+
+
+class TestDetectConflicts:
+    """Tests for conflict detection heuristics."""
+
+    def test_numeric_threshold_across_tiers(self):
+        """DTI 43% federal vs 40% internal should flag numeric_threshold."""
+        results = [
+            _make_result(
+                "The QM safe harbor requires DTI not exceed 43%",
+                tier=1,
+                source="ATR/QM Rule",
+            ),
+            _make_result(
+                "Summit Cap sets maximum DTI at 40%",
+                tier=3,
+                source="Summit Cap Policies",
+            ),
+        ]
+        conflicts = detect_conflicts(results)
+        assert len(conflicts) == 1
+        assert conflicts[0].conflict_type == "numeric_threshold"
+        assert "43" in conflicts[0].description
+        assert "40" in conflicts[0].description
+
+    def test_contradictory_directive_flagged(self):
+        """'must' vs 'must not' across results should flag contradictory_directive."""
+        results = [
+            _make_result(
+                "The lender must provide the appraisal copy to the applicant",
+                tier=1,
+            ),
+            _make_result(
+                "The lender must not share appraisal details before final review",
+                tier=3,
+            ),
+        ]
+        conflicts = detect_conflicts(results)
+        assert len(conflicts) == 1
+        assert conflicts[0].conflict_type == "contradictory_directive"
+
+    def test_same_tier_divergence(self):
+        """Two agency results with different limits should flag same_tier."""
+        results = [
+            _make_result(
+                "Maximum DTI ratio is 50% with DU approval",
+                tier=2,
+                source="Fannie Mae",
+            ),
+            _make_result(
+                "Back-end ratio must not exceed 43%",
+                tier=2,
+                source="FHA Guidelines",
+            ),
+        ]
+        conflicts = detect_conflicts(results)
+        assert len(conflicts) >= 1
+        type_found = any(c.conflict_type == "same_tier" for c in conflicts)
+        assert type_found
+
+    def test_no_false_positives_complementary(self):
+        """Different topics should not be flagged as conflicts."""
+        results = [
+            _make_result(
+                "The Loan Estimate must be delivered within 3 business days",
+                tier=1,
+                source="TRID Rule",
+            ),
+            _make_result(
+                "All properties must meet minimum property requirements",
+                tier=2,
+                source="FHA Guidelines",
+            ),
+        ]
+        conflicts = detect_conflicts(results)
+        assert len(conflicts) == 0
+
+    def test_empty_results_no_conflicts(self):
+        """Empty input should return no conflicts."""
+        assert detect_conflicts([]) == []
+
+    def test_single_result_no_conflicts(self):
+        """Single result cannot have conflicts."""
+        results = [_make_result("Some text about 43% DTI", tier=1)]
+        assert detect_conflicts(results) == []

--- a/packages/api/tests/test_kb_tool.py
+++ b/packages/api/tests/test_kb_tool.py
@@ -1,0 +1,180 @@
+# This project was developed with assistance from AI tools.
+"""Tests for the kb_search agent tool."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.agents.compliance_tools import kb_search
+from src.services.compliance.knowledge_base.search import KBSearchResult
+
+
+def _make_result(
+    chunk_text: str,
+    tier: int,
+    source: str = "Test Doc",
+    section: str | None = "Test Section",
+    effective_date: str | None = "2024-01-01",
+) -> KBSearchResult:
+    """Create a KBSearchResult for testing."""
+    tier_labels = {1: "Federal Regulation", 2: "Agency Guideline", 3: "Internal Policy"}
+    return KBSearchResult(
+        chunk_text=chunk_text,
+        source_document=source,
+        section_ref=section,
+        tier=tier,
+        tier_label=tier_labels.get(tier, f"Tier {tier}"),
+        similarity=0.8,
+        boosted_similarity=0.8,
+        effective_date=effective_date,
+    )
+
+
+@pytest.fixture
+def agent_state():
+    """Minimal agent state dict for tool calls."""
+    return {
+        "user_id": "lo-test-001",
+        "user_role": "loan_officer",
+        "session_id": "test-session-123",
+    }
+
+
+@pytest.fixture
+def mock_session_factory():
+    """Create a mock SessionLocal context manager."""
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    mock_ctx = MagicMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_ctx, mock_session
+
+
+class TestKbSearchTool:
+    """Tests for the kb_search tool function."""
+
+    @pytest.mark.asyncio
+    async def test_formats_results_with_citations(self, agent_state, mock_session_factory):
+        """Output includes tier label, source, section, and text."""
+        mock_ctx, mock_session = mock_session_factory
+        results = [
+            _make_result(
+                "The QM safe harbor requires DTI not exceed 43%",
+                tier=1,
+                source="12 CFR 1026.43",
+                section="QM Safe Harbor",
+                effective_date="2014-01-10",
+            ),
+        ]
+
+        with (
+            patch("src.agents.compliance_tools.SessionLocal", return_value=mock_ctx),
+            patch(
+                "src.agents.compliance_tools.search_kb",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+            patch("src.agents.compliance_tools.detect_conflicts", return_value=[]),
+            patch("src.agents.compliance_tools.write_audit_event", new_callable=AsyncMock),
+        ):
+            output = await kb_search.ainvoke({"query": "DTI requirements", "state": agent_state})
+
+        assert "[Federal Regulation]" in output
+        assert "12 CFR 1026.43" in output
+        assert "QM Safe Harbor" in output
+        assert "2014-01-10" in output
+        assert "43%" in output
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_rephrase(self, agent_state, mock_session_factory):
+        """Empty results return a 'rephrase' message."""
+        mock_ctx, mock_session = mock_session_factory
+
+        with (
+            patch("src.agents.compliance_tools.SessionLocal", return_value=mock_ctx),
+            patch("src.agents.compliance_tools.search_kb", new_callable=AsyncMock, return_value=[]),
+            patch("src.agents.compliance_tools.write_audit_event", new_callable=AsyncMock),
+        ):
+            output = await kb_search.ainvoke({"query": "something obscure", "state": agent_state})
+
+        assert "rephrase" in output.lower() or "no relevant" in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_writes_audit_event(self, agent_state, mock_session_factory):
+        """Tool call writes an audit event with tool name and query."""
+        mock_ctx, mock_session = mock_session_factory
+        mock_audit = AsyncMock()
+
+        with (
+            patch("src.agents.compliance_tools.SessionLocal", return_value=mock_ctx),
+            patch("src.agents.compliance_tools.search_kb", new_callable=AsyncMock, return_value=[]),
+            patch("src.agents.compliance_tools.write_audit_event", mock_audit),
+        ):
+            await kb_search.ainvoke({"query": "DTI limits", "state": agent_state})
+
+        mock_audit.assert_called()
+        call_kwargs = mock_audit.call_args_list[0]
+        event_data = call_kwargs.kwargs.get("event_data") or call_kwargs[1].get("event_data")
+        assert event_data["tool"] == "kb_search"
+        assert event_data["query"] == "DTI limits"
+
+    @pytest.mark.asyncio
+    async def test_includes_regulatory_disclaimer(self, agent_state, mock_session_factory):
+        """Output always includes regulatory disclaimer."""
+        mock_ctx, mock_session = mock_session_factory
+        results = [_make_result("Some regulatory text", tier=1)]
+
+        with (
+            patch("src.agents.compliance_tools.SessionLocal", return_value=mock_ctx),
+            patch(
+                "src.agents.compliance_tools.search_kb",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+            patch("src.agents.compliance_tools.detect_conflicts", return_value=[]),
+            patch("src.agents.compliance_tools.write_audit_event", new_callable=AsyncMock),
+        ):
+            output = await kb_search.ainvoke({"query": "any query", "state": agent_state})
+
+        assert "simulated for demonstration purposes" in output
+
+    @pytest.mark.asyncio
+    async def test_conflict_section_in_output(self, agent_state, mock_session_factory):
+        """When conflicts detected, output includes CONFLICTS DETECTED section."""
+        mock_ctx, mock_session = mock_session_factory
+        results = [
+            _make_result("DTI max 43%", tier=1),
+            _make_result("DTI max 40%", tier=3),
+        ]
+
+        from src.services.compliance.knowledge_base.conflict import Conflict
+
+        conflicts = [
+            Conflict(
+                result_a=results[0],
+                result_b=results[1],
+                conflict_type="numeric_threshold",
+                description="Federal cites 43% while Internal cites 40%",
+            )
+        ]
+
+        with (
+            patch("src.agents.compliance_tools.SessionLocal", return_value=mock_ctx),
+            patch(
+                "src.agents.compliance_tools.search_kb",
+                new_callable=AsyncMock,
+                return_value=results,
+            ),
+            patch("src.agents.compliance_tools.detect_conflicts", return_value=conflicts),
+            patch("src.agents.compliance_tools.write_audit_event", new_callable=AsyncMock),
+        ):
+            output = await kb_search.ainvoke({"query": "DTI limits", "state": agent_state})
+
+        assert "CONFLICTS DETECTED" in output
+        assert "Numeric Threshold" in output
+        assert "43%" in output
+        assert "40%" in output


### PR DESCRIPTION
## Summary
- Add `kb_search` LangGraph tool: vector search with tier-labeled citations, audit logging, regulatory disclaimer
- Add conflict detection module: numeric thresholds across tiers, contradictory directives, same-tier divergence
- Integrate `kb_search` into loan officer assistant (tool list + YAML config + system prompt)
- Audit trail: tool_call events for every search, system events for detected conflicts

## Test plan
- [x] 6 new conflict detection tests (numeric threshold, contradictory directive, same-tier, no false positives, edge cases)
- [x] 5 new tool tests (citations format, empty results, audit event, disclaimer, conflict section)
- [x] Full suite passes (400 tests)
- [x] Lint clean (ruff check)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>