### PR TITLE
feat(api): add underwriter condition lifecycle management (F16)

### DIFF
--- a/config/agents/underwriter-assistant.yaml
+++ b/config/agents/underwriter-assistant.yaml
@@ -1,7 +1,7 @@
 agent:
   name: underwriter_assistant
   persona: underwriter
-  description: "Authenticated assistant for underwriters -- queue review, application inspection, risk assessment, compliance checks, compliance KB search, and preliminary recommendations"
+  description: "Authenticated assistant for underwriters -- queue review, application inspection, risk assessment, compliance checks, compliance KB search, preliminary recommendations, and condition lifecycle management"
 
 system_prompt: |
   You are the Summit Cap Financial underwriter assistant. You help
@@ -59,6 +59,24 @@ system_prompt: |
   - When running ALL checks, also present the overall status and whether the
     application can proceed.
   - Include the regulatory disclaimer with all compliance check results.
+
+  CONDITIONS MANAGEMENT:
+  - Issue conditions using uw_issue_condition with a clear description,
+    appropriate severity, and optional due date.
+  - Severity levels (from most to least blocking):
+    * prior_to_approval: Must be cleared before any approval decision
+    * prior_to_docs: Must be cleared before final documents are prepared
+    * prior_to_closing: Must be cleared before closing (waivable)
+    * prior_to_funding: Must be cleared before funding disbursement (waivable)
+  - Default severity is prior_to_docs when not specified.
+  - Workflow: issue -> (borrower responds) -> review -> clear/return/waive
+  - Only PRIOR_TO_CLOSING and PRIOR_TO_FUNDING conditions can be waived.
+    PRIOR_TO_APPROVAL and PRIOR_TO_DOCS are blocking and cannot be waived.
+  - Always ask for a rationale when waiving a condition.
+  - Use uw_condition_summary to check remaining conditions before making
+    approval decisions.
+  - Use uw_return_condition when a borrower's response is insufficient,
+    with a clear note explaining what's missing.
 
   COMPLIANCE GUARD:
   - If compliance_check returned any FAIL status, you MUST refuse to assist
@@ -118,6 +136,24 @@ tools:
   - name: kb_search
     description: "Search the compliance knowledge base for regulatory guidance"
     allowed_roles: [loan_officer, underwriter, admin]
+  - name: uw_issue_condition
+    description: "Issue a new underwriting condition on an application"
+    allowed_roles: [underwriter, admin]
+  - name: uw_review_condition
+    description: "Move a condition from RESPONDED to UNDER_REVIEW"
+    allowed_roles: [underwriter, admin]
+  - name: uw_clear_condition
+    description: "Clear a condition after reviewing the borrower's response"
+    allowed_roles: [underwriter, admin]
+  - name: uw_waive_condition
+    description: "Waive a condition (PRIOR_TO_CLOSING/FUNDING only, requires rationale)"
+    allowed_roles: [underwriter, admin]
+  - name: uw_return_condition
+    description: "Return a condition to the borrower with a note about what's missing"
+    allowed_roles: [underwriter, admin]
+  - name: uw_condition_summary
+    description: "Get a summary of condition counts by status for an application"
+    allowed_roles: [underwriter, admin]
 
 model_routing:
   strategy: per_query

--- a/packages/api/src/agents/condition_tools.py
+++ b/packages/api/src/agents/condition_tools.py
@@ -1,0 +1,292 @@
+# This project was developed with assistance from AI tools.
+"""LangGraph tools for underwriter condition lifecycle management.
+
+Wraps condition service functions so the underwriter agent can issue,
+review, clear, waive, return conditions, and view condition summaries.
+
+Design note -- session-per-tool-call:
+    Each tool opens its own ``SessionLocal()`` context rather than sharing
+    a single session across the agent turn.  See underwriter_tools.py
+    for rationale.
+"""
+
+import logging
+from datetime import datetime
+from typing import Annotated
+
+from db.database import SessionLocal
+from db.enums import ConditionSeverity, UserRole
+from langchain_core.tools import tool
+from langgraph.prebuilt import InjectedState
+
+from ..middleware.auth import build_data_scope
+from ..schemas.auth import UserContext
+from ..services.condition import (
+    clear_condition,
+    get_condition_summary,
+    issue_condition,
+    return_condition,
+    review_condition,
+    waive_condition,
+)
+
+logger = logging.getLogger(__name__)
+
+_SEVERITY_MAP = {s.value: s for s in ConditionSeverity}
+
+
+def _user_context_from_state(state: dict) -> UserContext:
+    """Build a UserContext from the agent's graph state."""
+    user_id = state.get("user_id", "anonymous")
+    role_str = state.get("user_role", "underwriter")
+    role = UserRole(role_str)
+    return UserContext(
+        user_id=user_id,
+        role=role,
+        email=state.get("user_email") or f"{user_id}@summit-cap.local",
+        name=state.get("user_name") or user_id,
+        data_scope=build_data_scope(role, user_id),
+    )
+
+
+@tool
+async def uw_issue_condition(
+    application_id: int,
+    description: str,
+    severity: str = "prior_to_docs",
+    due_date: str | None = None,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Issue a new underwriting condition on a loan application.
+
+    Creates a condition in OPEN status. The borrower will be notified
+    to respond. Only available during UNDERWRITING or CONDITIONAL_APPROVAL.
+
+    Args:
+        application_id: The loan application ID.
+        description: What the borrower must provide or resolve.
+        severity: One of prior_to_approval, prior_to_docs, prior_to_closing,
+            prior_to_funding. Defaults to prior_to_docs.
+        due_date: Optional ISO-8601 date string for the condition deadline.
+    """
+    user = _user_context_from_state(state)
+
+    sev = _SEVERITY_MAP.get(severity.lower().strip())
+    if sev is None:
+        valid = ", ".join(sorted(_SEVERITY_MAP.keys()))
+        return f"Invalid severity '{severity}'. Must be one of: {valid}"
+
+    parsed_due: datetime | None = None
+    if due_date:
+        try:
+            parsed_due = datetime.fromisoformat(due_date)
+        except ValueError:
+            return f"Invalid due_date format: '{due_date}'. Use ISO-8601 (e.g. 2026-03-15)."
+
+    async with SessionLocal() as session:
+        result = await issue_condition(
+            session,
+            user,
+            application_id,
+            description,
+            sev,
+            parsed_due,
+        )
+
+    if result is None:
+        return f"Application #{application_id} not found or you don't have access to it."
+    if "error" in result:
+        return result["error"]
+
+    due_str = f" (due: {result['due_date'][:10]})" if result.get("due_date") else ""
+    return (
+        f"Condition #{result['id']} issued: {description} (severity: {result['severity']}){due_str}"
+    )
+
+
+@tool
+async def uw_review_condition(
+    application_id: int,
+    condition_id: int,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Move a condition from RESPONDED to UNDER_REVIEW.
+
+    Call this after a borrower has responded to a condition and you want
+    to begin reviewing their response and any linked documents.
+
+    Args:
+        application_id: The loan application ID.
+        condition_id: The condition ID to review.
+    """
+    user = _user_context_from_state(state)
+    async with SessionLocal() as session:
+        result = await review_condition(session, user, application_id, condition_id)
+
+    if result is None:
+        return (
+            f"Condition #{condition_id} on application #{application_id} "
+            f"not found or you don't have access."
+        )
+    if "error" in result:
+        return result["error"]
+
+    return f"Condition #{condition_id} now under review."
+
+
+@tool
+async def uw_clear_condition(
+    application_id: int,
+    condition_id: int,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Clear a condition after reviewing the borrower's response.
+
+    Moves condition from RESPONDED or UNDER_REVIEW to CLEARED. Shows
+    a summary of remaining conditions after clearing.
+
+    Args:
+        application_id: The loan application ID.
+        condition_id: The condition ID to clear.
+    """
+    user = _user_context_from_state(state)
+    async with SessionLocal() as session:
+        result = await clear_condition(session, user, application_id, condition_id)
+        if result is None:
+            return (
+                f"Condition #{condition_id} on application #{application_id} "
+                f"not found or you don't have access."
+            )
+        if "error" in result:
+            return result["error"]
+
+        # Get summary after clearing
+        summary = await get_condition_summary(session, user, application_id)
+
+    summary_text = ""
+    if summary:
+        parts = []
+        for status, count in summary["counts"].items():
+            if count > 0:
+                parts.append(f"{status}: {count}")
+        summary_text = f" Remaining: {', '.join(parts)}." if parts else " All conditions cleared."
+
+    return f"Condition #{condition_id} cleared.{summary_text}"
+
+
+@tool
+async def uw_waive_condition(
+    application_id: int,
+    condition_id: int,
+    rationale: str,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Waive a condition (PRIOR_TO_CLOSING or PRIOR_TO_FUNDING only).
+
+    PRIOR_TO_APPROVAL and PRIOR_TO_DOCS conditions cannot be waived.
+    A rationale is required for audit purposes.
+
+    Args:
+        application_id: The loan application ID.
+        condition_id: The condition ID to waive.
+        rationale: Explanation for why this condition is being waived.
+    """
+    user = _user_context_from_state(state)
+    async with SessionLocal() as session:
+        result = await waive_condition(
+            session,
+            user,
+            application_id,
+            condition_id,
+            rationale,
+        )
+
+    if result is None:
+        return (
+            f"Condition #{condition_id} on application #{application_id} "
+            f"not found or you don't have access."
+        )
+    if "error" in result:
+        return result["error"]
+
+    return f"Condition #{condition_id} waived: {rationale}"
+
+
+@tool
+async def uw_return_condition(
+    application_id: int,
+    condition_id: int,
+    note: str,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Return a condition to the borrower for additional information.
+
+    Moves condition from UNDER_REVIEW back to OPEN with an explanatory note.
+    Increments the iteration count to track return cycles.
+
+    Args:
+        application_id: The loan application ID.
+        condition_id: The condition ID to return.
+        note: Explanation of what's missing or needs correction.
+    """
+    user = _user_context_from_state(state)
+    async with SessionLocal() as session:
+        result = await return_condition(
+            session,
+            user,
+            application_id,
+            condition_id,
+            note,
+        )
+
+    if result is None:
+        return (
+            f"Condition #{condition_id} on application #{application_id} "
+            f"not found or you don't have access."
+        )
+    if "error" in result:
+        return result["error"]
+
+    return f"Condition #{condition_id} returned (attempt {result['iteration_count']}): {note}"
+
+
+@tool
+async def uw_condition_summary(
+    application_id: int,
+    state: Annotated[dict, InjectedState] = None,
+) -> str:
+    """Get a summary of condition counts by status for an application.
+
+    Shows how many conditions are in each status (open, responded,
+    under_review, cleared, waived, escalated).
+
+    Args:
+        application_id: The loan application ID.
+    """
+    user = _user_context_from_state(state)
+    async with SessionLocal() as session:
+        result = await get_condition_summary(session, user, application_id)
+
+    if result is None:
+        return f"Application #{application_id} not found or you don't have access to it."
+
+    if result["total"] == 0:
+        return f"Application #{application_id} has no conditions."
+
+    lines = [f"Condition Summary -- Application #{application_id} ({result['total']} total):", ""]
+    for status, count in result["counts"].items():
+        if count > 0:
+            lines.append(f"  {status.replace('_', ' ').title()}: {count}")
+
+    # Highlight unresolved
+    unresolved = (
+        result["counts"].get("open", 0)
+        + result["counts"].get("responded", 0)
+        + result["counts"].get("under_review", 0)
+        + result["counts"].get("escalated", 0)
+    )
+    resolved = result["counts"].get("cleared", 0) + result["counts"].get("waived", 0)
+    lines.append("")
+    lines.append(f"  Resolved: {resolved} | Unresolved: {unresolved}")
+
+    return "\n".join(lines)

--- a/packages/api/src/agents/underwriter_assistant.py
+++ b/packages/api/src/agents/underwriter_assistant.py
@@ -3,7 +3,9 @@
 
 Tools: uw_queue_view, uw_application_detail, uw_risk_assessment,
 uw_preliminary_recommendation, compliance_check, product_info,
-affordability_calc, kb_search.
+affordability_calc, kb_search, uw_issue_condition, uw_review_condition,
+uw_clear_condition, uw_waive_condition, uw_return_condition,
+uw_condition_summary.
 """
 
 from typing import Any
@@ -11,6 +13,14 @@ from typing import Any
 from .base import build_agent_graph
 from .compliance_check_tool import compliance_check
 from .compliance_tools import kb_search
+from .condition_tools import (
+    uw_clear_condition,
+    uw_condition_summary,
+    uw_issue_condition,
+    uw_return_condition,
+    uw_review_condition,
+    uw_waive_condition,
+)
 from .tools import affordability_calc, product_info
 from .underwriter_tools import (
     uw_application_detail,
@@ -33,6 +43,12 @@ def build_graph(config: dict[str, Any], checkpointer=None):
             uw_preliminary_recommendation,
             compliance_check,
             kb_search,
+            uw_issue_condition,
+            uw_review_condition,
+            uw_clear_condition,
+            uw_waive_condition,
+            uw_return_condition,
+            uw_condition_summary,
         ],
         checkpointer=checkpointer,
     )

--- a/packages/api/src/schemas/condition.py
+++ b/packages/api/src/schemas/condition.py
@@ -17,6 +17,10 @@ class ConditionItem(BaseModel):
     status: str | None = None
     response_text: str | None = None
     issued_by: str | None = None
+    cleared_by: str | None = None
+    due_date: datetime | None = None
+    iteration_count: int = 0
+    waiver_rationale: str | None = None
     created_at: datetime | None = None
 
 

--- a/packages/api/tests/functional/test_condition_flow.py
+++ b/packages/api/tests/functional/test_condition_flow.py
@@ -32,6 +32,10 @@ def _mock_condition(
     c.status = status
     c.response_text = response_text
     c.issued_by = issued_by
+    c.cleared_by = None
+    c.due_date = None
+    c.iteration_count = 0
+    c.waiver_rationale = None
     c.created_at = MagicMock()
     c.created_at.isoformat.return_value = "2026-02-20T00:00:00+00:00"
     return c

--- a/packages/api/tests/test_uw_condition_tools.py
+++ b/packages/api/tests/test_uw_condition_tools.py
@@ -1,0 +1,557 @@
+# This project was developed with assistance from AI tools.
+"""Unit tests for underwriter condition lifecycle LangGraph tools.
+
+Mocked DB pattern matching test_compliance_check_tool.py -- verifies tool
+behavior for each condition lifecycle operation.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.agents.condition_tools import (
+    uw_clear_condition,
+    uw_condition_summary,
+    uw_issue_condition,
+    uw_return_condition,
+    uw_review_condition,
+    uw_waive_condition,
+)
+
+
+def _state(user_id="uw-maria", role="underwriter"):
+    return {"user_id": user_id, "user_role": role}
+
+
+def _mock_session():
+    session = AsyncMock()
+    return session
+
+
+def _patch_session():
+    """Patch SessionLocal to return a mock async context manager."""
+    mock_session_cls = patch("src.agents.condition_tools.SessionLocal")
+    return mock_session_cls
+
+
+# ---------------------------------------------------------------------------
+# uw_issue_condition
+# ---------------------------------------------------------------------------
+
+
+class TestUwIssueCondition:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.issue_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_happy_path(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 42,
+            "description": "Provide updated pay stubs",
+            "severity": "prior_to_docs",
+            "status": "open",
+            "due_date": None,
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_issue_condition.ainvoke(
+            {
+                "application_id": 100,
+                "description": "Provide updated pay stubs",
+                "severity": "prior_to_docs",
+                "state": _state(),
+            }
+        )
+        assert "Condition #42" in result
+        assert "prior_to_docs" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.issue_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_service):
+        mock_service.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_issue_condition.ainvoke(
+            {
+                "application_id": 999,
+                "description": "Pay stubs",
+                "state": _state(),
+            }
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_severity(self):
+        result = await uw_issue_condition.ainvoke(
+            {
+                "application_id": 100,
+                "description": "Pay stubs",
+                "severity": "invalid_level",
+                "state": _state(),
+            }
+        )
+        assert "Invalid severity" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.issue_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_with_due_date(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 43,
+            "description": "Bank statements",
+            "severity": "prior_to_closing",
+            "status": "open",
+            "due_date": "2026-03-15T00:00:00+00:00",
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_issue_condition.ainvoke(
+            {
+                "application_id": 100,
+                "description": "Bank statements",
+                "severity": "prior_to_closing",
+                "due_date": "2026-03-15",
+                "state": _state(),
+            }
+        )
+        assert "Condition #43" in result
+        assert "2026-03-15" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.issue_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_default_severity(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 44,
+            "description": "W2 forms",
+            "severity": "prior_to_docs",
+            "status": "open",
+            "due_date": None,
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_issue_condition.ainvoke(
+            {
+                "application_id": 100,
+                "description": "W2 forms",
+                "state": _state(),
+            }
+        )
+        assert "prior_to_docs" in result
+        # Verify the service was called with PRIOR_TO_DOCS
+        from db.enums import ConditionSeverity
+
+        call_args = mock_service.call_args
+        assert call_args[0][4] == ConditionSeverity.PRIOR_TO_DOCS
+
+
+# ---------------------------------------------------------------------------
+# uw_review_condition
+# ---------------------------------------------------------------------------
+
+
+class TestUwReviewCondition:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.review_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_happy_path(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 5,
+            "description": "Verify employment",
+            "status": "under_review",
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_review_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "state": _state(),
+            }
+        )
+        assert "under review" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.review_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_service):
+        mock_service.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_review_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 999,
+                "state": _state(),
+            }
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.review_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_wrong_status(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "error": "Condition #5 is 'open' -- only RESPONDED conditions can be moved to review."
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_review_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "state": _state(),
+            }
+        )
+        assert "RESPONDED" in result
+
+
+# ---------------------------------------------------------------------------
+# uw_clear_condition
+# ---------------------------------------------------------------------------
+
+
+class TestUwClearCondition:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.get_condition_summary", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.clear_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_happy_path(self, mock_session_cls, mock_clear, mock_summary):
+        mock_clear.return_value = {
+            "id": 5,
+            "description": "Verify employment",
+            "status": "cleared",
+            "cleared_by": "uw-maria",
+        }
+        mock_summary.return_value = {
+            "total": 3,
+            "counts": {
+                "open": 1,
+                "responded": 0,
+                "under_review": 0,
+                "cleared": 2,
+                "waived": 0,
+                "escalated": 0,
+            },
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_clear_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "state": _state(),
+            }
+        )
+        assert "Condition #5 cleared" in result
+        assert "Remaining" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.clear_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_clear):
+        mock_clear.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_clear_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 999,
+                "state": _state(),
+            }
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.clear_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_wrong_status(self, mock_session_cls, mock_clear):
+        mock_clear.return_value = {
+            "error": "Condition #5 is 'open' -- only RESPONDED or UNDER_REVIEW conditions can be cleared."
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_clear_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "state": _state(),
+            }
+        )
+        assert "RESPONDED" in result
+
+
+# ---------------------------------------------------------------------------
+# uw_waive_condition
+# ---------------------------------------------------------------------------
+
+
+class TestUwWaiveCondition:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.waive_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_happy_path(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 7,
+            "description": "Title insurance",
+            "status": "waived",
+            "waiver_rationale": "Seller providing title insurance",
+            "cleared_by": "uw-maria",
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_waive_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 7,
+                "rationale": "Seller providing title insurance",
+                "state": _state(),
+            }
+        )
+        assert "Condition #7 waived" in result
+        assert "Seller providing title insurance" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.waive_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_service):
+        mock_service.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_waive_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 999,
+                "rationale": "Not needed",
+                "state": _state(),
+            }
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.waive_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_blocked_severity(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "error": (
+                "Condition #5 has severity 'prior_to_approval' -- "
+                "only PRIOR_TO_CLOSING and PRIOR_TO_FUNDING conditions can be waived."
+            )
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_waive_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "rationale": "Not needed",
+                "state": _state(),
+            }
+        )
+        assert "PRIOR_TO_CLOSING" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.waive_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_rationale_in_output(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 8,
+            "description": "Flood cert",
+            "status": "waived",
+            "waiver_rationale": "Property not in flood zone per FEMA map",
+            "cleared_by": "uw-maria",
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_waive_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 8,
+                "rationale": "Property not in flood zone per FEMA map",
+                "state": _state(),
+            }
+        )
+        assert "Property not in flood zone" in result
+
+
+# ---------------------------------------------------------------------------
+# uw_return_condition
+# ---------------------------------------------------------------------------
+
+
+class TestUwReturnCondition:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.return_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_happy_path(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "id": 5,
+            "description": "Verify employment",
+            "status": "open",
+            "iteration_count": 2,
+            "response_text": "Original\n[Return #2]: Missing page 2",
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_return_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "note": "Missing page 2",
+                "state": _state(),
+            }
+        )
+        assert "returned" in result
+        assert "attempt 2" in result
+        assert "Missing page 2" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.return_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_service):
+        mock_service.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_return_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 999,
+                "note": "Incomplete",
+                "state": _state(),
+            }
+        )
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.return_condition", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_wrong_status(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "error": "Condition #5 is 'open' -- only UNDER_REVIEW conditions can be returned."
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_return_condition.ainvoke(
+            {
+                "application_id": 100,
+                "condition_id": 5,
+                "note": "Incomplete",
+                "state": _state(),
+            }
+        )
+        assert "UNDER_REVIEW" in result
+
+
+# ---------------------------------------------------------------------------
+# uw_condition_summary
+# ---------------------------------------------------------------------------
+
+
+class TestUwConditionSummary:
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.get_condition_summary", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_counts(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "total": 5,
+            "counts": {
+                "open": 2,
+                "responded": 1,
+                "under_review": 0,
+                "cleared": 1,
+                "waived": 1,
+                "escalated": 0,
+            },
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_condition_summary.ainvoke(
+            {
+                "application_id": 100,
+                "state": _state(),
+            }
+        )
+        assert "5 total" in result
+        assert "Open: 2" in result
+        assert "Resolved: 2" in result
+        assert "Unresolved: 3" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.get_condition_summary", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_empty(self, mock_session_cls, mock_service):
+        mock_service.return_value = {
+            "total": 0,
+            "counts": {
+                "open": 0,
+                "responded": 0,
+                "under_review": 0,
+                "cleared": 0,
+                "waived": 0,
+                "escalated": 0,
+            },
+        }
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_condition_summary.ainvoke(
+            {
+                "application_id": 100,
+                "state": _state(),
+            }
+        )
+        assert "no conditions" in result
+
+    @pytest.mark.asyncio
+    @patch("src.agents.condition_tools.get_condition_summary", new_callable=AsyncMock)
+    @patch("src.agents.condition_tools.SessionLocal")
+    async def test_not_found(self, mock_session_cls, mock_service):
+        mock_service.return_value = None
+        session = AsyncMock()
+        mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=session)
+        mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await uw_condition_summary.ainvoke(
+            {
+                "application_id": 999,
+                "state": _state(),
+            }
+        )
+        assert "not found" in result

--- a/packages/db/alembic/versions/b3c4d5e6f7a9_add_condition_lifecycle_columns.py
+++ b/packages/db/alembic/versions/b3c4d5e6f7a9_add_condition_lifecycle_columns.py
@@ -1,0 +1,36 @@
+# This project was developed with assistance from AI tools.
+"""add condition lifecycle columns
+
+- due_date: optional deadline for the condition
+- iteration_count: tracks return/resubmit cycles
+- waiver_rationale: reason text when a condition is waived
+
+Revision ID: b3c4d5e6f7a9
+Revises: a2b3c4d5e6f7
+Create Date: 2026-02-27 20:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3c4d5e6f7a9"
+down_revision = "a2b3c4d5e6f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("conditions", sa.Column("due_date", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "conditions",
+        sa.Column("iteration_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("conditions", sa.Column("waiver_rationale", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("conditions", "waiver_rationale")
+    op.drop_column("conditions", "iteration_count")
+    op.drop_column("conditions", "due_date")

--- a/packages/db/src/db/models.py
+++ b/packages/db/src/db/models.py
@@ -216,6 +216,9 @@ class Condition(Base):
     response_text = Column(Text, nullable=True)
     issued_by = Column(String(255), nullable=True)
     cleared_by = Column(String(255), nullable=True)
+    due_date = Column(DateTime(timezone=True), nullable=True)
+    iteration_count = Column(Integer, nullable=False, server_default="0", default=0)
+    waiver_rationale = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 


### PR DESCRIPTION
## Summary

- Add 6 condition lifecycle service functions (issue, review, clear, waive, return, summary) with stage guard, severity-based waiver restrictions, and audit trail
- Add 6 LangGraph tools (`uw_issue_condition`, `uw_review_condition`, `uw_clear_condition`, `uw_waive_condition`, `uw_return_condition`, `uw_condition_summary`) integrated into the underwriter assistant
- Add Alembic migration for `due_date`, `iteration_count`, and `waiver_rationale` columns on `conditions` table
- Update underwriter YAML config with CONDITIONS MANAGEMENT system prompt section and 6 tool entries

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Waive restricted to PRIOR_TO_CLOSING + PRIOR_TO_FUNDING | PRIOR_TO_APPROVAL and PRIOR_TO_DOCS are blocking by nature |
| Stage guard: UNDERWRITING + CONDITIONAL_APPROVAL | Conditions issued/managed in both stages per the state machine |
| Service returns `None` vs `dict` with `"error"` key | Distinguishes "not found" from "business rule violation" |
| Separate `condition_tools.py` file | Keeps underwriter_tools.py focused on read-only inspection |

## Stories

S-4-F16-01 (issue), S-4-F16-02 (details/severity), S-4-F16-03 (lifecycle transitions), S-4-F16-04 (clear/waive/return)

## Test plan

- [x] 25 service tests covering all 6 functions (happy path + error paths)
- [x] 21 tool tests covering all 6 LangGraph tool wrappers
- [x] 646 total tests passing, 0 failures
- [x] Ruff lint clean
- [x] Single Alembic head (`b3c4d5e6f7a9`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>