### PR TITLE
fix(api): address 7 critical findings from pre-phase-5 review

### DIFF
--- a/deploy/helm/summit-cap/templates/api-configmap.yaml
+++ b/deploy/helm/summit-cap/templates/api-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.api.name }}-config
+  labels:
+    {{- include "summit-cap.api.labels" . | nindent 4 }}
+data:
+  models.yaml: |
+    {{- .Values.api.config.modelsYaml | nindent 4 }}
+{{- end }}

--- a/deploy/helm/summit-cap/templates/api-deployment.yaml
+++ b/deploy/helm/summit-cap/templates/api-deployment.yaml
@@ -121,6 +121,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "summit-cap.fullname" . }}-secret
                   key: LANGFUSE_HOST
+            - name: SQLADMIN_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: SQLADMIN_SECRET_KEY
           {{- if .Values.api.healthCheck.enabled }}
           livenessProbe:
             httpGet:
@@ -137,6 +142,14 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.api.name }}-config
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/summit-cap/templates/secret.yaml
+++ b/deploy/helm/summit-cap/templates/secret.yaml
@@ -30,6 +30,7 @@ data:
   LANGFUSE_PUBLIC_KEY: {{ .Values.secrets.LANGFUSE_PUBLIC_KEY | toString | b64enc | quote }}
   LANGFUSE_SECRET_KEY: {{ .Values.secrets.LANGFUSE_SECRET_KEY | toString | b64enc | quote }}
   LANGFUSE_HOST: {{ .Values.secrets.LANGFUSE_HOST | toString | b64enc | quote }}
+  SQLADMIN_SECRET_KEY: {{ .Values.secrets.SQLADMIN_SECRET_KEY | toString | b64enc | quote }}
 
   # UI environment variables
   VITE_API_BASE_URL: {{ .Values.secrets.VITE_API_BASE_URL | toString | b64enc | quote }}

--- a/deploy/helm/summit-cap/values.yaml
+++ b/deploy/helm/summit-cap/values.yaml
@@ -41,6 +41,9 @@ secrets:
   LANGFUSE_SECRET_KEY: ""
   LANGFUSE_HOST: ""
 
+  # Admin panel
+  SQLADMIN_SECRET_KEY: "change-me-in-production"
+
   # UI secrets
   VITE_API_BASE_URL: "http://localhost:8000"
   VITE_ENVIRONMENT: "production"
@@ -85,6 +88,19 @@ api:
     path: /health/
     initialDelaySeconds: 30
     periodSeconds: 10
+  config:
+    modelsYaml: |
+      routing:
+        default_tier: capable_large
+        classification:
+          strategy: rule_based
+      tiers:
+        fast:
+          endpoint: "${LLM_BASE_URL:-http://localhost:11434/v1}"
+          model_name: "${LLM_MODEL_FAST:-gpt-4o-mini}"
+        capable_large:
+          endpoint: "${LLM_BASE_URL:-http://localhost:11434/v1}"
+          model_name: "${LLM_MODEL_CAPABLE:-gpt-4o-mini}"
 # UI configuration
 ui:
   enabled: true

--- a/packages/api/Containerfile
+++ b/packages/api/Containerfile
@@ -43,6 +43,9 @@ COPY packages/api/pyproject.toml ./packages/api/
 # Copy DB package source (API depends on it via editable install)
 COPY packages/db/ ./packages/db/
 
+# Copy config files (models.yaml, agent configs, keycloak realm)
+COPY config/ ./config/
+
 # Set working directory to API package
 WORKDIR /app/packages/api
 

--- a/packages/api/src/admin.py
+++ b/packages/api/src/admin.py
@@ -8,8 +8,6 @@ When AUTH_DISABLED=false, requires admin credentials via login form.
 When AUTH_DISABLED=true, admin panel is open (dev mode).
 """
 
-import secrets
-
 from db import (
     Application,
     ApplicationFinancials,
@@ -212,7 +210,9 @@ class DemoDataManifestAdmin(ModelView, model=DemoDataManifest):
 
 def setup_admin(app):
     """Set up SQLAdmin and mount it to the FastAPI app."""
-    auth_backend = AdminAuth(secret_key=secrets.token_urlsafe(32))
+    auth_backend = AdminAuth(
+        secret_key=settings.SQLADMIN_SECRET_KEY,
+    )
     admin = Admin(app, engine, title="Summit Cap Admin", authentication_backend=auth_backend)
 
     admin.add_view(BorrowerAdmin)

--- a/packages/api/src/agents/base.py
+++ b/packages/api/src/agents/base.py
@@ -226,8 +226,8 @@ def build_routed_graph(
 
         user_role = state.get("user_role", "")
         user_id = state.get("user_id", "anonymous")
-        # Merge graph-level defaults with any per-invocation overrides
-        roles_map = {**(tool_allowed_roles or {}), **state.get("tool_allowed_roles", {})}
+        # Use graph-level defaults only -- never allow state to override roles
+        roles_map = dict(tool_allowed_roles or {})
 
         blocked: list[str] = []
         for tc in last.tool_calls:

--- a/packages/api/src/agents/decision_tools.py
+++ b/packages/api/src/agents/decision_tools.py
@@ -70,8 +70,10 @@ async def _compliance_gate(session, application_id: int) -> str | None:
             f"check found for application #{application_id}."
         )
 
-    if comp_event.event_data and comp_event.event_data.get("status") == "FAIL":
-        failed_checks = comp_event.event_data.get("failed_checks", [])
+    event_data = comp_event.event_data or {}
+    overall = event_data.get("overall_status") or event_data.get("status")
+    if overall == "FAIL" or not event_data.get("can_proceed", True):
+        failed_checks = event_data.get("failed_checks", [])
         failed_str = ", ".join(failed_checks) if failed_checks else "one or more checks"
         return (
             f"Cannot approve application #{application_id} -- compliance check "

--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -64,6 +64,10 @@ class Settings(BaseSettings):
         default="admin",
         description="Password for SQLAdmin login (ignored when AUTH_DISABLED=true).",
     )
+    SQLADMIN_SECRET_KEY: str = Field(
+        default="change-me-in-production",
+        description="Secret key for SQLAdmin session cookies. Must be stable across restarts.",
+    )
 
     # -- Safety / Shields --
     SAFETY_MODEL: str | None = Field(

--- a/packages/api/src/main.py
+++ b/packages/api/src/main.py
@@ -21,6 +21,7 @@ from .routes import (
     applications,
     borrower_chat,
     chat,
+    decisions,
     documents,
     health,
     hmda,
@@ -127,6 +128,7 @@ app.include_router(chat.router, prefix="/api", tags=["chat"])
 app.include_router(borrower_chat.router, prefix="/api", tags=["chat"])
 app.include_router(loan_officer_chat.router, prefix="/api", tags=["chat"])
 app.include_router(underwriter_chat.router, prefix="/api", tags=["chat"])
+app.include_router(decisions.router, prefix="/api/applications", tags=["decisions"])
 app.include_router(documents.router, prefix="/api", tags=["documents"])
 app.include_router(hmda.router, prefix="/api/hmda", tags=["hmda"])
 app.include_router(admin.router, prefix="/api/admin", tags=["admin"])

--- a/packages/api/src/routes/decisions.py
+++ b/packages/api/src/routes/decisions.py
@@ -1,0 +1,88 @@
+# This project was developed with assistance from AI tools.
+"""Decision REST endpoints (read-only)."""
+
+from db import get_db
+from db.enums import UserRole
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..middleware.auth import CurrentUser, require_roles
+from ..schemas import Pagination
+from ..schemas.decision import DecisionItem, DecisionListResponse, DecisionResponse
+from ..services.decision import get_decisions
+
+router = APIRouter()
+
+
+@router.get(
+    "/{application_id}/decisions",
+    response_model=DecisionListResponse,
+    dependencies=[
+        Depends(
+            require_roles(
+                UserRole.ADMIN,
+                UserRole.LOAN_OFFICER,
+                UserRole.UNDERWRITER,
+                UserRole.CEO,
+            )
+        )
+    ],
+)
+async def list_decisions(
+    application_id: int,
+    user: CurrentUser,
+    session: AsyncSession = Depends(get_db),
+) -> DecisionListResponse:
+    """List all decisions for an application."""
+    result = await get_decisions(session, user, application_id)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Application not found",
+        )
+    items = [DecisionItem(**d) for d in result]
+    return DecisionListResponse(
+        data=items,
+        pagination=Pagination(
+            total=len(items),
+            offset=0,
+            limit=len(items),
+            has_more=False,
+        ),
+    )
+
+
+@router.get(
+    "/{application_id}/decisions/{decision_id}",
+    response_model=DecisionResponse,
+    dependencies=[
+        Depends(
+            require_roles(
+                UserRole.ADMIN,
+                UserRole.LOAN_OFFICER,
+                UserRole.UNDERWRITER,
+                UserRole.CEO,
+            )
+        )
+    ],
+)
+async def get_decision(
+    application_id: int,
+    decision_id: int,
+    user: CurrentUser,
+    session: AsyncSession = Depends(get_db),
+) -> DecisionResponse:
+    """Get a single decision by ID."""
+    result = await get_decisions(session, user, application_id)
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Application not found",
+        )
+    for d in result:
+        if d["id"] == decision_id:
+            return DecisionResponse(data=DecisionItem(**d))
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Decision not found",
+    )

--- a/packages/api/tests/test_decisions_route.py
+++ b/packages/api/tests/test_decisions_route.py
@@ -1,0 +1,104 @@
+# This project was developed with assistance from AI tools.
+"""Tests for decision REST endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def _mock_decisions():
+    """Patch get_decisions to return synthetic data."""
+    decisions = [
+        {
+            "id": 1,
+            "application_id": 100,
+            "decision_type": "approve",
+            "rationale": "Strong financials",
+            "ai_recommendation": "Approve",
+            "ai_agreement": True,
+            "override_rationale": None,
+            "denial_reasons": None,
+            "credit_score_used": 750,
+            "credit_score_source": "Experian",
+            "contributing_factors": None,
+            "decided_by": "uw-maria",
+            "created_at": "2026-01-15T10:00:00",
+        },
+        {
+            "id": 2,
+            "application_id": 100,
+            "decision_type": "conditional_approval",
+            "rationale": "Pending docs",
+            "ai_recommendation": None,
+            "ai_agreement": None,
+            "override_rationale": None,
+            "denial_reasons": None,
+            "credit_score_used": None,
+            "credit_score_source": None,
+            "contributing_factors": None,
+            "decided_by": "uw-maria",
+            "created_at": "2026-01-16T10:00:00",
+        },
+    ]
+    with patch("src.routes.decisions.get_decisions", new_callable=AsyncMock) as mock:
+        mock.return_value = decisions
+        yield mock
+
+
+@pytest.fixture()
+def _mock_decisions_not_found():
+    """Patch get_decisions to return None (app not found)."""
+    with patch("src.routes.decisions.get_decisions", new_callable=AsyncMock) as mock:
+        mock.return_value = None
+        yield mock
+
+
+@pytest.mark.usefixtures("_mock_decisions")
+class TestListDecisions:
+    """GET /api/applications/{id}/decisions"""
+
+    def test_list_decisions_returns_data(self, client):
+        resp = client.get("/api/applications/100/decisions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["data"]) == 2
+        assert body["data"][0]["id"] == 1
+        assert body["data"][1]["decision_type"] == "conditional_approval"
+        assert body["pagination"]["total"] == 2
+
+    def test_list_decisions_has_pagination(self, client):
+        resp = client.get("/api/applications/100/decisions")
+        body = resp.json()
+        assert "pagination" in body
+        assert body["pagination"]["has_more"] is False
+
+
+@pytest.mark.usefixtures("_mock_decisions_not_found")
+class TestListDecisionsNotFound:
+    def test_returns_404_when_app_not_found(self, client):
+        resp = client.get("/api/applications/999/decisions")
+        assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("_mock_decisions")
+class TestGetDecision:
+    """GET /api/applications/{id}/decisions/{did}"""
+
+    def test_get_single_decision(self, client):
+        resp = client.get("/api/applications/100/decisions/1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"]["id"] == 1
+        assert body["data"]["rationale"] == "Strong financials"
+
+    def test_get_decision_not_found(self, client):
+        resp = client.get("/api/applications/100/decisions/999")
+        assert resp.status_code == 404
+
+
+@pytest.mark.usefixtures("_mock_decisions_not_found")
+class TestGetDecisionAppNotFound:
+    def test_returns_404_when_app_not_found(self, client):
+        resp = client.get("/api/applications/999/decisions/1")
+        assert resp.status_code == 404

--- a/packages/api/tests/test_extraction.py
+++ b/packages/api/tests/test_extraction.py
@@ -147,20 +147,17 @@ class TestExtractTextFromPdf:
     """pymupdf text extraction from PDF bytes."""
 
     def test_extract_text_from_pdf(self):
-        svc = ExtractionService()
-        result = svc._extract_text_from_pdf(_get_minimal_pdf())
+        result = ExtractionService._extract_text_from_pdf_sync(_get_minimal_pdf())
         assert result is not None
         assert "Hello World" in result
         assert len(result) >= 50
 
     def test_corrupted_pdf_returns_none(self):
-        svc = ExtractionService()
-        result = svc._extract_text_from_pdf(b"not a pdf at all")
+        result = ExtractionService._extract_text_from_pdf_sync(b"not a pdf at all")
         assert result is None
 
     def test_blank_pdf_returns_short_text(self):
-        svc = ExtractionService()
-        result = svc._extract_text_from_pdf(_get_blank_pdf())
+        result = ExtractionService._extract_text_from_pdf_sync(_get_blank_pdf())
         assert result is not None
         assert len(result) < 50
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -399,7 +399,7 @@ Database configuration is managed via environment variables:
 
 ```env
 # Database connection (project root .env file)
-DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/summit-cap
+DATABASE_URL=postgresql+asyncpg://user:password@localhost:5433/summit-cap
 DB_ECHO=false  # Set to true for SQL query logging
 ```
 
@@ -412,7 +412,7 @@ postgresql+asyncpg://[user[:password]@][host[:port]][/database]
 **Components:**
 - `postgresql+asyncpg`: Driver specification (required for async)
 - `user:password`: Database credentials
-- `host:port`: Database server (default: localhost:5432)
+- `host:port`: Database server (default: localhost:5433 via compose)
 - `database`: Database name
 
 ### Database Container
@@ -421,7 +421,7 @@ The database runs in a Podman container managed from the project root:
 
 - **Service Name**: summit-cap-db
 - **Host**: localhost
-- **Port**: 5432
+- **Port**: 5433 (host) / 5432 (container)
 - **Database**: summit-cap
 - **Username**: user
 - **Password**: password


### PR DESCRIPTION
## Summary

Addresses 7 critical findings (C-3, C-7, C-8, C-9, C-11, C-12, C-13) from the pre-Phase 5 comprehensive review (16 specialist agents).

- **C-3 Tool RBAC privilege escalation**: Removed `state.get("tool_allowed_roles")` merge in agent base -- roles are now immutable at graph construction time
- **C-7 SQLAdmin session secret**: Sourced from `SQLADMIN_SECRET_KEY` env var instead of regenerating on every restart (broke multi-worker sessions)
- **C-8 Compliance gate no-op**: Fixed key lookup (`status` -> `overall_status`) + added `can_proceed` check -- gate was silently passing failed compliance
- **C-9 Blocking PDF operations**: Wrapped synchronous pymupdf calls in `run_in_executor()` to avoid blocking the async event loop
- **C-11 Stale documentation**: Rewrote API README with all Phase 3-4 endpoints, fixed HMDA path and DB port references
- **C-12 Missing decision endpoints**: Added `GET /api/applications/{id}/decisions` and `.../decisions/{did}` REST endpoints (6 tests)
- **C-13 Helm config volume**: Containerfile now copies `config/`; Helm chart adds ConfigMap + volume mount for agent/model configs

## Test plan

- [x] 856 tests passing (850 existing + 6 new decision route tests)
- [x] Ruff lint clean
- [x] Pre-commit hooks pass (format, lint, HMDA isolation)
- [ ] Verify decision endpoints via Swagger UI after deploy
- [ ] Verify Helm template renders correctly (`helm template`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>