### PR TITLE
feat(api): add LO performance metrics endpoint (F12, S-5-F12-04)

### DIFF
--- a/packages/api/src/schemas/analytics.py
+++ b/packages/api/src/schemas/analytics.py
@@ -38,6 +38,31 @@ class PipelineSummary(BaseModel):
     computed_at: datetime
 
 
+class LOPerformanceRow(BaseModel):
+    """Performance metrics for a single loan officer."""
+
+    lo_id: str = Field(..., description="Loan officer user ID")
+    lo_name: str | None = Field(None, description="Loan officer display name (if available)")
+    active_count: int = Field(..., description="Applications in active pipeline stages")
+    closed_count: int = Field(..., description="Applications closed in the time period")
+    pull_through_rate: float = Field(..., description="Closed / total initiated by this LO (%)")
+    avg_days_to_underwriting: float | None = Field(
+        None, description="Avg days from Application to Underwriting submission"
+    )
+    avg_days_conditions_to_cleared: float | None = Field(
+        None, description="Avg days from condition issued to cleared (LO responsiveness)"
+    )
+    denial_rate: float = Field(..., description="Percentage of LO's decided applications denied")
+
+
+class LOPerformanceSummary(BaseModel):
+    """LO performance comparison table for CEO dashboard."""
+
+    loan_officers: list[LOPerformanceRow]
+    time_range_days: int
+    computed_at: datetime
+
+
 class DenialReason(BaseModel):
     """A single denial reason with count."""
 


### PR DESCRIPTION
## Summary

- Add `GET /api/analytics/lo-performance` endpoint for CEO dashboard LO comparison
- Per-LO metrics: active/closed counts, pull-through rate, avg days to underwriting, avg condition clearance time, denial rate
- Optional product and time range filters
- CEO/Admin RBAC protection
- 23 unit/functional tests + 13 integration tests against real PostgreSQL
- 906 total tests passing, no regressions

## Test plan

- [x] `AUTH_DISABLED=true pytest tests/test_analytics.py -v` -- 23/23 pass
- [x] `AUTH_DISABLED=true pytest tests/integration/test_analytics.py -v` -- 13/13 pass (real DB)
- [x] `AUTH_DISABLED=true pytest -v` -- 906/906 pass
- [x] `ruff check` -- clean

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>