### PR TITLE
fix(api): use explicit join for product-filtered denial trends

### DIFF
--- a/packages/api/tests/test_hmda.py
+++ b/packages/api/tests/test_hmda.py
@@ -4,6 +4,7 @@
 import subprocess
 from datetime import datetime
 from decimal import Decimal
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -999,6 +1000,6 @@ def test_lint_hmda_isolation():
         ["bash", "scripts/lint-hmda-isolation.sh"],
         capture_output=True,
         text=True,
-        cwd="/home/jary/redhat/git/mortgage-ai",
+        cwd=str(Path(__file__).resolve().parents[3]),
     )
     assert result.returncode == 0, f"HMDA isolation lint failed:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary
- Replace `.has()` subquery with explicit `JOIN` to Application table when product filter is applied in denial trends query
- Fix hardcoded absolute path in HMDA lint isolation test to use `Path(__file__).resolve().parents[3]`

## Test plan
- [x] `uv run pytest tests/test_hmda.py` passes
- [x] `uv run pytest tests/test_analytics.py` passes
- [x] Live tests 127/127

Generated-by: Claude Code