### PR TITLE
feat(deploy): add Keycloak and MinIO Helm templates (F23)

### DIFF
--- a/deploy/helm/summit-cap/files/summit-cap-realm.json
+++ b/deploy/helm/summit-cap/files/summit-cap-realm.json
@@ -1,0 +1,102 @@
+{
+  "realm": "summit-cap",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "accessTokenLifespan": 900,
+  "ssoSessionMaxLifespan": 28800,
+  "ssoSessionIdleTimeout": 28800,
+  "roles": {
+    "realm": [
+      { "name": "admin", "description": "System administrator" },
+      { "name": "prospect", "description": "Unauthenticated or newly registered visitor" },
+      { "name": "borrower", "description": "Mortgage applicant" },
+      { "name": "loan_officer", "description": "Loan origination officer" },
+      { "name": "underwriter", "description": "Mortgage underwriter" },
+      { "name": "ceo", "description": "Executive with read-only analytics access" }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "summit-cap-ui",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": ["http://localhost:3000/*", "http://localhost:5173/*"],
+      "webOrigins": ["http://localhost:3000", "http://localhost:5173"],
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
+    },
+    {
+      "clientId": "summit-cap-api",
+      "enabled": true,
+      "bearerOnly": true,
+      "protocol": "openid-connect"
+    }
+  ],
+  "users": [
+    {
+      "id": "d1a2b3c4-e5f6-7890-abcd-ef1234567801",
+      "username": "sarah.mitchell",
+      "enabled": true,
+      "email": "sarah.mitchell@example.com",
+      "firstName": "Sarah",
+      "lastName": "Mitchell",
+      "credentials": [
+        { "type": "password", "value": "demo", "temporary": false }
+      ],
+      "realmRoles": ["borrower"]
+    },
+    {
+      "id": "d1a2b3c4-e5f6-7890-abcd-ef1234567802",
+      "username": "james.torres",
+      "enabled": true,
+      "email": "james.torres@summit-cap.com",
+      "firstName": "James",
+      "lastName": "Torres",
+      "credentials": [
+        { "type": "password", "value": "demo", "temporary": false }
+      ],
+      "realmRoles": ["loan_officer"]
+    },
+    {
+      "id": "d1a2b3c4-e5f6-7890-abcd-ef1234567803",
+      "username": "maria.chen",
+      "enabled": true,
+      "email": "maria.chen@summit-cap.com",
+      "firstName": "Maria",
+      "lastName": "Chen",
+      "credentials": [
+        { "type": "password", "value": "demo", "temporary": false }
+      ],
+      "realmRoles": ["underwriter"]
+    },
+    {
+      "id": "d1a2b3c4-e5f6-7890-abcd-ef1234567804",
+      "username": "david.park",
+      "enabled": true,
+      "email": "david.park@summit-cap.com",
+      "firstName": "David",
+      "lastName": "Park",
+      "credentials": [
+        { "type": "password", "value": "demo", "temporary": false }
+      ],
+      "realmRoles": ["ceo"]
+    },
+    {
+      "id": "d1a2b3c4-e5f6-7890-abcd-ef1234567805",
+      "username": "admin",
+      "enabled": true,
+      "email": "admin@summit-cap.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "credentials": [
+        { "type": "password", "value": "admin", "temporary": false }
+      ],
+      "realmRoles": ["admin"]
+    }
+  ]
+}

--- a/deploy/helm/summit-cap/templates/_helpers.tpl
+++ b/deploy/helm/summit-cap/templates/_helpers.tpl
@@ -118,3 +118,35 @@ Database selector labels
 app.kubernetes.io/component: database
 {{- end }}
 
+{{/*
+Keycloak labels
+*/}}
+{{- define "summit-cap.keycloak.labels" -}}
+{{ include "summit-cap.labels" . }}
+app.kubernetes.io/component: keycloak
+{{- end }}
+
+{{/*
+Keycloak selector labels
+*/}}
+{{- define "summit-cap.keycloak.selectorLabels" -}}
+{{ include "summit-cap.selectorLabels" . }}
+app.kubernetes.io/component: keycloak
+{{- end }}
+
+{{/*
+MinIO labels
+*/}}
+{{- define "summit-cap.minio.labels" -}}
+{{ include "summit-cap.labels" . }}
+app.kubernetes.io/component: minio
+{{- end }}
+
+{{/*
+MinIO selector labels
+*/}}
+{{- define "summit-cap.minio.selectorLabels" -}}
+{{ include "summit-cap.selectorLabels" . }}
+app.kubernetes.io/component: minio
+{{- end }}
+

--- a/deploy/helm/summit-cap/templates/keycloak.yaml
+++ b/deploy/helm/summit-cap/templates/keycloak.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.keycloak.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.keycloak.name }}-realm
+  labels:
+    {{- include "summit-cap.keycloak.labels" . | nindent 4 }}
+data:
+  summit-cap-realm.json: |
+    {{- .Files.Get "files/summit-cap-realm.json" | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.keycloak.name }}
+  labels:
+    {{- include "summit-cap.keycloak.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "summit-cap.keycloak.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.keycloak.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      containers:
+        - name: keycloak
+          image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          args:
+            - start-dev
+            - --import-realm
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: KC_BOOTSTRAP_ADMIN_PASSWORD
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+          volumeMounts:
+            - name: realm-config
+              mountPath: /opt/keycloak/data/import
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
+          resources:
+            {{- toYaml .Values.keycloak.resources | nindent 12 }}
+      volumes:
+        - name: realm-config
+          configMap:
+            name: {{ .Values.keycloak.name }}-realm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.keycloak.name }}
+  labels:
+    {{- include "summit-cap.keycloak.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "summit-cap.keycloak.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/summit-cap/templates/minio.yaml
+++ b/deploy/helm/summit-cap/templates/minio.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.minio.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.minio.name }}
+  labels:
+    {{- include "summit-cap.minio.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "summit-cap.minio.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.minio.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      containers:
+        - name: minio
+          image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command:
+            - sh
+            - -c
+            - >-
+              mkdir -p /data/langfuse /data/documents &&
+              exec minio server --address ":9000"
+              --console-address ":9001" /data
+          ports:
+            - name: api
+              containerPort: 9000
+              protocol: TCP
+            - name: console
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: MINIO_ROOT_PASSWORD
+          volumeMounts:
+            - name: minio-storage
+              mountPath: /data
+          livenessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /minio/health/live
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.minio.resources | nindent 12 }}
+      volumes:
+        - name: minio-storage
+          {{- if .Values.minio.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.minio.name }}-pvc
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+{{- if .Values.minio.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.minio.name }}-pvc
+  labels:
+    {{- include "summit-cap.minio.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
+  storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.minio.persistence.size }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.minio.name }}
+  labels:
+    {{- include "summit-cap.minio.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9000
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: 9001
+      targetPort: console
+      protocol: TCP
+      name: console
+  selector:
+    {{- include "summit-cap.minio.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/summit-cap/templates/secret.yaml
+++ b/deploy/helm/summit-cap/templates/secret.yaml
@@ -56,3 +56,11 @@ data:
   # UI
   VITE_API_BASE_URL: {{ .Values.secrets.VITE_API_BASE_URL | toString | b64enc | quote }}
   VITE_ENVIRONMENT: {{ .Values.secrets.VITE_ENVIRONMENT | toString | b64enc | quote }}
+
+  # Keycloak admin
+  KC_BOOTSTRAP_ADMIN_USERNAME: {{ .Values.secrets.KC_BOOTSTRAP_ADMIN_USERNAME | toString | b64enc | quote }}
+  KC_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.secrets.KC_BOOTSTRAP_ADMIN_PASSWORD | toString | b64enc | quote }}
+
+  # MinIO
+  MINIO_ROOT_USER: {{ .Values.secrets.MINIO_ROOT_USER | toString | b64enc | quote }}
+  MINIO_ROOT_PASSWORD: {{ .Values.secrets.MINIO_ROOT_PASSWORD | toString | b64enc | quote }}

--- a/deploy/helm/summit-cap/values.yaml
+++ b/deploy/helm/summit-cap/values.yaml
@@ -58,6 +58,14 @@ secrets:
   # UI secrets
   VITE_API_BASE_URL: "http://localhost:8000"
   VITE_ENVIRONMENT: "production"
+
+  # Keycloak admin
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KC_BOOTSTRAP_ADMIN_PASSWORD: "admin"
+
+  # MinIO
+  MINIO_ROOT_USER: "minio"
+  MINIO_ROOT_PASSWORD: "miniosecret"
 # OpenShift Routes configuration
 routes:
   enabled: true
@@ -143,6 +151,39 @@ database:
     limits:
       memory: "512Mi"
       cpu: "500m"
+# Keycloak configuration
+keycloak:
+  enabled: true
+  name: keycloak
+  image:
+    repository: quay.io/keycloak/keycloak
+    tag: "26.0"
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+# MinIO configuration
+minio:
+  enabled: true
+  name: minio
+  image:
+    repository: minio/minio
+    tag: latest
+  persistence:
+    enabled: true
+    size: 10Gi
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
 # ServiceAccount
 serviceAccount:
   create: true


### PR DESCRIPTION
## Summary
- Add keycloak.yaml: Deployment + Service + realm ConfigMap (gated by `keycloak.enabled`)
- Add minio.yaml: Deployment + Service + conditional PVC (gated by `minio.enabled`)
- Copy realm JSON into chart `files/` for ConfigMap rendering
- Add keycloak + minio label helpers, secret entries, and values sections

Stacked on #82.

## Test plan
- [x] `helm lint ./deploy/helm/summit-cap` passes
- [x] `helm template` renders keycloak Deployment, Service, and realm ConfigMap
- [x] `helm template` renders minio Deployment, Service, and PVC
- [x] Realm JSON content appears in rendered ConfigMap

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>