### PR TITLE
feat(deploy): add LangFuse observability stack templates (F23)

### DIFF
--- a/deploy/helm/summit-cap/templates/clickhouse.yaml
+++ b/deploy/helm/summit-cap/templates/clickhouse.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.langfuse.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+spec:
+  replicas: 1
+  serviceName: clickhouse
+  selector:
+    matchLabels:
+      {{- include "summit-cap.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: clickhouse
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: clickhouse
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8123
+              protocol: TCP
+            - name: native
+              containerPort: 9000
+              protocol: TCP
+          env:
+            - name: CLICKHOUSE_DB
+              value: default
+            - name: CLICKHOUSE_USER
+              value: clickhouse
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: CLICKHOUSE_PASSWORD
+          volumeMounts:
+            - name: clickhouse-data
+              mountPath: /var/lib/clickhouse
+            - name: clickhouse-logs
+              mountPath: /var/log/clickhouse-server
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+  volumeClaimTemplates:
+    - metadata:
+        name: clickhouse-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.global.storageClass }}
+        storageClassName: {{ .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: 10Gi
+    - metadata:
+        name: clickhouse-logs
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.global.storageClass }}
+        storageClassName: {{ .Values.global.storageClass }}
+        {{- end }}
+        resources:
+          requests:
+            storage: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8123
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 9000
+      targetPort: native
+      protocol: TCP
+      name: native
+  selector:
+    {{- include "summit-cap.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+{{- end }}

--- a/deploy/helm/summit-cap/templates/langfuse.yaml
+++ b/deploy/helm/summit-cap/templates/langfuse.yaml
@@ -1,0 +1,366 @@
+{{- if .Values.langfuse.enabled }}
+{{- $secretName := printf "%s-secret" (include "summit-cap.fullname" .) }}
+{{- $dbName := .Values.database.name }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: langfuse-web
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "summit-cap.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: langfuse-web
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: langfuse-web
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      initContainers:
+        - name: wait-for-deps
+          image: postgres:16-alpine
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Waiting for postgres..."
+              until pg_isready -h {{ $dbName }} -U "$POSTGRES_USER"; do sleep 3; done
+              echo "Dependencies ready!"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_USER
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: POSTGRES_PASSWORD
+      containers:
+        - name: langfuse-web
+          image: "{{ .Values.langfuse.web.image.repository }}:{{ .Values.langfuse.web.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.secrets.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ $dbName }}:5432/langfuse"
+            - name: HOSTNAME
+              value: "0.0.0.0"
+            - name: NEXTAUTH_URL
+              value: "http://langfuse-web:3000"
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: NEXTAUTH_SECRET
+            - name: SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_SALT
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_ENCRYPTION_KEY
+            - name: TELEMETRY_ENABLED
+              value: "false"
+            - name: LANGFUSE_INIT_ORG_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_ORG_ID
+            - name: LANGFUSE_INIT_ORG_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_ORG_NAME
+            - name: LANGFUSE_INIT_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_ID
+            - name: LANGFUSE_INIT_PROJECT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_NAME
+            - name: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+            - name: LANGFUSE_INIT_PROJECT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_SECRET_KEY
+            - name: LANGFUSE_INIT_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_EMAIL
+            - name: LANGFUSE_INIT_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_NAME
+            - name: LANGFUSE_INIT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_PASSWORD
+            - name: CLICKHOUSE_MIGRATION_URL
+              value: "clickhouse://clickhouse:{{ .Values.secrets.CLICKHOUSE_PASSWORD }}@clickhouse:9000/default"
+            - name: CLICKHOUSE_URL
+              value: "http://clickhouse:8123"
+            - name: CLICKHOUSE_USER
+              value: clickhouse
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: CLICKHOUSE_PASSWORD
+            - name: CLICKHOUSE_CLUSTER_ENABLED
+              value: "false"
+            - name: REDIS_HOST
+              value: redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: REDIS_AUTH
+            - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
+              value: langfuse
+            - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
+              value: us-east-1
+            - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_USER
+            - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
+              value: "http://{{ .Values.minio.name }}:9000"
+            - name: LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE
+              value: "true"
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
+              value: langfuse
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
+              value: us-east-1
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_USER
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
+              value: "http://{{ .Values.minio.name }}:9000"
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE
+              value: "true"
+          livenessProbe:
+            httpGet:
+              path: /api/public/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              path: /api/public/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 10
+          resources:
+            {{- toYaml .Values.langfuse.web.resources | nindent 12 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: langfuse-worker
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "summit-cap.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: langfuse-worker
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: langfuse-worker
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      containers:
+        - name: langfuse-worker
+          image: "{{ .Values.langfuse.worker.image.repository }}:{{ .Values.langfuse.worker.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: DATABASE_URL
+              value: "postgresql://{{ .Values.secrets.POSTGRES_USER }}:{{ .Values.secrets.POSTGRES_PASSWORD }}@{{ $dbName }}:5432/langfuse"
+            - name: NEXTAUTH_URL
+              value: "http://langfuse-web:3000"
+            - name: NEXTAUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: NEXTAUTH_SECRET
+            - name: SALT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_SALT
+            - name: ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_ENCRYPTION_KEY
+            - name: TELEMETRY_ENABLED
+              value: "false"
+            - name: LANGFUSE_INIT_ORG_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_ORG_ID
+            - name: LANGFUSE_INIT_ORG_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_ORG_NAME
+            - name: LANGFUSE_INIT_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_ID
+            - name: LANGFUSE_INIT_PROJECT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_NAME
+            - name: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_PUBLIC_KEY
+            - name: LANGFUSE_INIT_PROJECT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_PROJECT_SECRET_KEY
+            - name: LANGFUSE_INIT_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_EMAIL
+            - name: LANGFUSE_INIT_USER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_NAME
+            - name: LANGFUSE_INIT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: LANGFUSE_INIT_USER_PASSWORD
+            - name: CLICKHOUSE_MIGRATION_URL
+              value: "clickhouse://clickhouse:{{ .Values.secrets.CLICKHOUSE_PASSWORD }}@clickhouse:9000/default"
+            - name: CLICKHOUSE_URL
+              value: "http://clickhouse:8123"
+            - name: CLICKHOUSE_USER
+              value: clickhouse
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: CLICKHOUSE_PASSWORD
+            - name: CLICKHOUSE_CLUSTER_ENABLED
+              value: "false"
+            - name: REDIS_HOST
+              value: redis
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: REDIS_AUTH
+            - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
+              value: langfuse
+            - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
+              value: us-east-1
+            - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_USER
+            - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
+              value: "http://{{ .Values.minio.name }}:9000"
+            - name: LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE
+              value: "true"
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
+              value: langfuse
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
+              value: us-east-1
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_USER
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: MINIO_ROOT_PASSWORD
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
+              value: "http://{{ .Values.minio.name }}:9000"
+            - name: LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE
+              value: "true"
+          resources:
+            {{- toYaml .Values.langfuse.worker.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: langfuse-web
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse-web
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "summit-cap.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse-web
+{{- end }}

--- a/deploy/helm/summit-cap/templates/redis.yaml
+++ b/deploy/helm/summit-cap/templates/redis.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.langfuse.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  serviceName: redis
+  selector:
+    matchLabels:
+      {{- include "summit-cap.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command:
+            - redis-server
+            - --requirepass
+            - $(REDIS_AUTH)
+            - --maxmemory-policy
+            - noeviction
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          env:
+            - name: REDIS_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: REDIS_AUTH
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - -a
+                - $(REDIS_AUTH)
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - -a
+                - $(REDIS_AUTH)
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    {{- include "summit-cap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "summit-cap.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/deploy/helm/summit-cap/templates/secret.yaml
+++ b/deploy/helm/summit-cap/templates/secret.yaml
@@ -64,3 +64,19 @@ data:
   # MinIO
   MINIO_ROOT_USER: {{ .Values.secrets.MINIO_ROOT_USER | toString | b64enc | quote }}
   MINIO_ROOT_PASSWORD: {{ .Values.secrets.MINIO_ROOT_PASSWORD | toString | b64enc | quote }}
+
+  # LangFuse stack
+  NEXTAUTH_SECRET: {{ .Values.secrets.NEXTAUTH_SECRET | toString | b64enc | quote }}
+  LANGFUSE_SALT: {{ .Values.secrets.LANGFUSE_SALT | toString | b64enc | quote }}
+  LANGFUSE_ENCRYPTION_KEY: {{ .Values.secrets.LANGFUSE_ENCRYPTION_KEY | toString | b64enc | quote }}
+  LANGFUSE_INIT_ORG_ID: {{ .Values.secrets.LANGFUSE_INIT_ORG_ID | toString | b64enc | quote }}
+  LANGFUSE_INIT_ORG_NAME: {{ .Values.secrets.LANGFUSE_INIT_ORG_NAME | toString | b64enc | quote }}
+  LANGFUSE_INIT_PROJECT_ID: {{ .Values.secrets.LANGFUSE_INIT_PROJECT_ID | toString | b64enc | quote }}
+  LANGFUSE_INIT_PROJECT_NAME: {{ .Values.secrets.LANGFUSE_INIT_PROJECT_NAME | toString | b64enc | quote }}
+  LANGFUSE_INIT_PROJECT_PUBLIC_KEY: {{ .Values.secrets.LANGFUSE_INIT_PROJECT_PUBLIC_KEY | toString | b64enc | quote }}
+  LANGFUSE_INIT_PROJECT_SECRET_KEY: {{ .Values.secrets.LANGFUSE_INIT_PROJECT_SECRET_KEY | toString | b64enc | quote }}
+  LANGFUSE_INIT_USER_EMAIL: {{ .Values.secrets.LANGFUSE_INIT_USER_EMAIL | toString | b64enc | quote }}
+  LANGFUSE_INIT_USER_NAME: {{ .Values.secrets.LANGFUSE_INIT_USER_NAME | toString | b64enc | quote }}
+  LANGFUSE_INIT_USER_PASSWORD: {{ .Values.secrets.LANGFUSE_INIT_USER_PASSWORD | toString | b64enc | quote }}
+  CLICKHOUSE_PASSWORD: {{ .Values.secrets.CLICKHOUSE_PASSWORD | toString | b64enc | quote }}
+  REDIS_AUTH: {{ .Values.secrets.REDIS_AUTH | toString | b64enc | quote }}

--- a/deploy/helm/summit-cap/values.yaml
+++ b/deploy/helm/summit-cap/values.yaml
@@ -66,6 +66,22 @@ secrets:
   # MinIO
   MINIO_ROOT_USER: "minio"
   MINIO_ROOT_PASSWORD: "miniosecret"
+
+  # LangFuse stack
+  NEXTAUTH_SECRET: "mysecret"
+  LANGFUSE_SALT: "mysalt"
+  LANGFUSE_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+  LANGFUSE_INIT_ORG_ID: "summit-cap"
+  LANGFUSE_INIT_ORG_NAME: "Summit Cap Financial"
+  LANGFUSE_INIT_PROJECT_ID: "summit-cap-dev"
+  LANGFUSE_INIT_PROJECT_NAME: "Summit Cap Dev"
+  LANGFUSE_INIT_PROJECT_PUBLIC_KEY: "pk-lf-dev-public"
+  LANGFUSE_INIT_PROJECT_SECRET_KEY: "sk-lf-dev-secret"
+  LANGFUSE_INIT_USER_EMAIL: "admin@summitcap.dev"
+  LANGFUSE_INIT_USER_NAME: "Admin"
+  LANGFUSE_INIT_USER_PASSWORD: "password"
+  CLICKHOUSE_PASSWORD: "clickhouse"
+  REDIS_AUTH: "myredissecret"
 # OpenShift Routes configuration
 routes:
   enabled: true
@@ -183,6 +199,32 @@ minio:
     limits:
       memory: "512Mi"
       cpu: "500m"
+
+# LangFuse observability stack (redis + clickhouse auto-enabled)
+langfuse:
+  enabled: false
+  web:
+    image:
+      repository: langfuse/langfuse
+      tag: "3"
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "250m"
+      limits:
+        memory: "1Gi"
+        cpu: "1000m"
+  worker:
+    image:
+      repository: langfuse/langfuse-worker
+      tag: "3"
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
 
 # ServiceAccount
 serviceAccount:


### PR DESCRIPTION
## Summary
- Add redis.yaml: StatefulSet + headless Service (gated by `langfuse.enabled`)
- Add clickhouse.yaml: StatefulSet + Service with data/logs volumeClaimTemplates
- Add langfuse.yaml: web + worker Deployments + Service, full env block mirroring compose.yml
- Add 14 langfuse-specific secrets to secret.yaml and values.yaml
- Single `langfuse.enabled` toggle brings up entire stack (default: false)

Stacked on #83.

## Test plan
- [x] `helm lint ./deploy/helm/summit-cap` passes
- [x] `helm template --set langfuse.enabled=true` renders redis, clickhouse, langfuse-web, langfuse-worker
- [x] `helm template` (default) renders 0 langfuse resources
- [x] Total rendered resource kinds >= 10 when langfuse enabled

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>