### PR TITLE
feat(deploy): add LlamaStack with InferenceService support (F23)

### DIFF
--- a/deploy/helm/summit-cap/templates/_helpers.tpl
+++ b/deploy/helm/summit-cap/templates/_helpers.tpl
@@ -150,3 +150,19 @@ MinIO selector labels
 app.kubernetes.io/component: minio
 {{- end }}
 
+{{/*
+LlamaStack labels
+*/}}
+{{- define "summit-cap.llamastack.labels" -}}
+{{ include "summit-cap.labels" . }}
+app.kubernetes.io/component: llamastack
+{{- end }}
+
+{{/*
+LlamaStack selector labels
+*/}}
+{{- define "summit-cap.llamastack.selectorLabels" -}}
+{{ include "summit-cap.selectorLabels" . }}
+app.kubernetes.io/component: llamastack
+{{- end }}
+

--- a/deploy/helm/summit-cap/templates/llamastack-configmap.yaml
+++ b/deploy/helm/summit-cap/templates/llamastack-configmap.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.llamastack.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llamastack-config
+  labels:
+    {{- include "summit-cap.llamastack.labels" . | nindent 4 }}
+data:
+  run.yaml: |
+    version: 2
+    distro_name: starter
+
+    apis:
+      - inference
+    {{- if .Values.llamastack.safety.enabled }}
+      - safety
+    {{- end }}
+
+    providers:
+      inference:
+        - provider_id: remote-openai
+          provider_type: remote::openai
+          config:
+            api_key: ${env.LLM_API_KEY:=not-needed}
+    {{- if and .Values.llamastack.inferenceService.enabled .Values.llamastack.inferenceService.endpoint }}
+            base_url: {{ .Values.llamastack.inferenceService.endpoint }}
+    {{- else }}
+            base_url: ${env.LLM_BASE_URL:=http://host.docker.internal:1234/v1}
+    {{- end }}
+    {{- if .Values.llamastack.safety.enabled }}
+      safety:
+        - provider_id: llama-guard
+          provider_type: inline::llama-guard
+          config:
+            excluded_categories: []
+
+    registered_resources:
+      shields:
+        - shield_id: content_safety
+          provider_id: llama-guard
+          provider_shield_id: ${env.SAFETY_MODEL:=meta-llama/Llama-Guard-3-8B}
+
+    safety:
+      default_shield_id: content_safety
+    {{- end }}
+
+    storage:
+      backends:
+        kv_default:
+          type: kv_sqlite
+          db_path: /tmp/llamastack/kvstore.db
+        sql_default:
+          type: sql_sqlite
+          db_path: /tmp/llamastack/sql_store.db
+      stores:
+        metadata:
+          namespace: registry
+          backend: kv_default
+
+    server:
+      port: 8321
+{{- end }}

--- a/deploy/helm/summit-cap/templates/llamastack.yaml
+++ b/deploy/helm/summit-cap/templates/llamastack.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.llamastack.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llamastack
+  labels:
+    {{- include "summit-cap.llamastack.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "summit-cap.llamastack.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "summit-cap.llamastack.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "summit-cap.serviceAccountName" . }}
+      containers:
+        - name: llamastack
+          image: "{{ .Values.llamastack.image.repository }}:{{ .Values.llamastack.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8321
+              protocol: TCP
+          env:
+            - name: RUN_CONFIG_PATH
+              value: /app/run.yaml
+            - name: LLM_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: LLM_BASE_URL
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: LLM_API_KEY
+            {{- if .Values.llamastack.safety.enabled }}
+            - name: SAFETY_MODEL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "summit-cap.fullname" . }}-secret
+                  key: SAFETY_MODEL
+            {{- end }}
+            {{- if .Values.llamastack.inferenceService.authTokenSecret }}
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.llamastack.inferenceService.authTokenSecret }}
+                  key: token
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/run.yaml
+              subPath: run.yaml
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.llamastack.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: llamastack-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llamastack
+  labels:
+    {{- include "summit-cap.llamastack.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8321
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "summit-cap.llamastack.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/summit-cap/values.yaml
+++ b/deploy/helm/summit-cap/values.yaml
@@ -226,6 +226,28 @@ langfuse:
         memory: "512Mi"
         cpu: "500m"
 
+# LlamaStack model serving
+llamastack:
+  enabled: false
+  image:
+    repository: llamastack/distribution-starter
+    tag: latest
+  # InferenceService support (OpenShift AI / KServe)
+  inferenceService:
+    enabled: false
+    endpoint: ""
+    # Optional: name of existing K8s Secret with 'token' key
+    authTokenSecret: ""
+  safety:
+    enabled: true
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
 # ServiceAccount
 serviceAccount:
   create: true


### PR DESCRIPTION
## Summary
- Add llamastack.yaml: Deployment + Service (gated by `llamastack.enabled`)
- Add llamastack-configmap.yaml: dynamic run.yaml from values
  - InferenceService mode: hardcoded `base_url` pointing to KServe endpoint
  - Default mode: env var substitution (`${env.LLM_BASE_URL}`)
- Optional auth token mount from named K8s Secret
- Safety shields toggled via `llamastack.safety.enabled`

Stacked on #84.

## Test plan
- [x] `helm lint ./deploy/helm/summit-cap` passes
- [x] InferenceService mode renders hardcoded `base_url`
- [x] Default mode renders env var substitution
- [x] Disabled by default (no llamastack resources in default render)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>