### PR TITLE
feat(deploy): consolidate values, add dev overlay, update deploy (F23)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,16 +201,11 @@ deploy: create-project push-images helm-dep-update
 deploy-dev: create-project push-images helm-dep-update
 	@echo "Deploying application in development mode..."
 	@scripts/deploy.sh \
-		--set database.persistence.enabled=false \
-		--set api.replicas=1 \
-		--set ui.replicas=1
+		-f deploy/helm/$(PROJECT_NAME)/values-dev.yaml
 
 undeploy:
 	@echo "Undeploying application..."
 	@helm uninstall $(PROJECT_NAME) --namespace $(NAMESPACE) || echo "Release $(PROJECT_NAME) not found"
-	@echo "Cleaning up migration jobs and pods..."
-	@oc delete job -l app.kubernetes.io/component=migration -n $(NAMESPACE) 2>/dev/null || true
-	@oc delete pod -l app.kubernetes.io/component=migration -n $(NAMESPACE) 2>/dev/null || true
 	@echo "Cleanup complete"
 
 status:

--- a/deploy/helm/summit-cap/values-dev.yaml
+++ b/deploy/helm/summit-cap/values-dev.yaml
@@ -1,0 +1,59 @@
+# Development overlay for summit-cap Helm chart
+#
+# Usage: helm install summit-cap ./deploy/helm/summit-cap -f deploy/helm/summit-cap/values-dev.yaml
+#
+# Disables auth, optional services, and persistence for fast local iteration.
+
+secrets:
+  AUTH_DISABLED: "true"
+  DEBUG: "true"
+
+# Smaller resource requests for local/dev clusters
+api:
+  replicas: 1
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+ui:
+  replicas: 1
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
+
+database:
+  persistence:
+    enabled: false
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "250m"
+
+# Disable optional services for minimal dev footprint
+keycloak:
+  enabled: false
+
+minio:
+  persistence:
+    enabled: false
+
+langfuse:
+  enabled: false
+
+llamastack:
+  enabled: false
+
+# Disable OpenShift routes (not available on local clusters)
+routes:
+  enabled: false

--- a/deploy/helm/summit-cap/values.yaml
+++ b/deploy/helm/summit-cap/values.yaml
@@ -1,4 +1,13 @@
 # Default values for summit-cap
+#
+# Override patterns:
+#   External DB:        --set database.enabled=false
+#                       --set secrets.DATABASE_URL=postgresql+asyncpg://...
+#   External Keycloak:  --set keycloak.enabled=false
+#                       --set secrets.KEYCLOAK_URL=https://...
+#   External MinIO/S3:  --set minio.enabled=false
+#                       --set secrets.S3_ENDPOINT=https://...
+#   Dev mode:           -f values-dev.yaml
 global:
   imageRegistry: quay.io
   imageRepository: summit-cap
@@ -6,7 +15,7 @@ global:
   imagePullPolicy: Always
   storageClass: ""
 
-# Secrets configuration - these values should be overridden with actual secrets
+# Secrets -- override these for real deployments via --set or external Secret
 secrets:
   # Database secrets
   POSTGRES_DB: "summit-cap"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -56,10 +56,42 @@ helm upgrade --install "$PROJECT_NAME" "./deploy/helm/$PROJECT_NAME" \
     --set secrets.POSTGRES_USER="${POSTGRES_USER:-}" \
     --set secrets.POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}" \
     --set secrets.DATABASE_URL="${DATABASE_URL:-}" \
+    --set secrets.COMPLIANCE_DATABASE_URL="${COMPLIANCE_DATABASE_URL:-}" \
     --set secrets.DEBUG="${DEBUG:-}" \
     --set secrets.ALLOWED_HOSTS="${ALLOWED_HOSTS:-}" \
+    --set secrets.AUTH_DISABLED="${AUTH_DISABLED:-}" \
+    --set secrets.KEYCLOAK_URL="${KEYCLOAK_URL:-}" \
+    --set secrets.KEYCLOAK_REALM="${KEYCLOAK_REALM:-}" \
+    --set secrets.KEYCLOAK_CLIENT_ID="${KEYCLOAK_CLIENT_ID:-}" \
+    --set secrets.JWKS_CACHE_TTL="${JWKS_CACHE_TTL:-}" \
+    --set secrets.S3_ENDPOINT="${S3_ENDPOINT:-}" \
+    --set secrets.S3_ACCESS_KEY="${S3_ACCESS_KEY:-}" \
+    --set secrets.S3_SECRET_KEY="${S3_SECRET_KEY:-}" \
+    --set secrets.S3_BUCKET="${S3_BUCKET:-}" \
+    --set secrets.S3_REGION="${S3_REGION:-}" \
+    --set secrets.UPLOAD_MAX_SIZE_MB="${UPLOAD_MAX_SIZE_MB:-}" \
+    --set secrets.LLM_API_KEY="${LLM_API_KEY:-}" \
+    --set secrets.LLM_BASE_URL="${LLM_BASE_URL:-}" \
+    --set secrets.LLM_MODEL_FAST="${LLM_MODEL_FAST:-}" \
+    --set secrets.LLM_MODEL_CAPABLE="${LLM_MODEL_CAPABLE:-}" \
+    --set secrets.SAFETY_MODEL="${SAFETY_MODEL:-}" \
+    --set secrets.SAFETY_ENDPOINT="${SAFETY_ENDPOINT:-}" \
+    --set secrets.SAFETY_API_KEY="${SAFETY_API_KEY:-}" \
+    --set secrets.LANGFUSE_PUBLIC_KEY="${LANGFUSE_PUBLIC_KEY:-}" \
+    --set secrets.LANGFUSE_SECRET_KEY="${LANGFUSE_SECRET_KEY:-}" \
+    --set secrets.LANGFUSE_HOST="${LANGFUSE_HOST:-}" \
+    --set secrets.SQLADMIN_USER="${SQLADMIN_USER:-}" \
+    --set secrets.SQLADMIN_PASSWORD="${SQLADMIN_PASSWORD:-}" \
+    --set secrets.SQLADMIN_SECRET_KEY="${SQLADMIN_SECRET_KEY:-}" \
     --set secrets.VITE_API_BASE_URL="${VITE_API_BASE_URL:-}" \
     --set secrets.VITE_ENVIRONMENT="${VITE_ENVIRONMENT:-}" \
+    --set secrets.KC_BOOTSTRAP_ADMIN_USERNAME="${KC_BOOTSTRAP_ADMIN_USERNAME:-}" \
+    --set secrets.KC_BOOTSTRAP_ADMIN_PASSWORD="${KC_BOOTSTRAP_ADMIN_PASSWORD:-}" \
+    --set secrets.MINIO_ROOT_USER="${MINIO_ROOT_USER:-}" \
+    --set secrets.MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-}" \
+    --set keycloak.enabled="${KEYCLOAK_ENABLED:-true}" \
+    --set llamastack.enabled="${LLAMASTACK_ENABLED:-false}" \
+    --set langfuse.enabled="${LANGFUSE_ENABLED:-false}" \
     "$@" \
     $HELM_EXTRA_ARGS \
     || {


### PR DESCRIPTION
## Summary
- Add override pattern docs to values.yaml header (external DB, external Keycloak, external S3, dev mode)
- Create values-dev.yaml: AUTH_DISABLED, DEBUG, smaller resources, no persistence, optional services disabled
- Update deploy.sh: pass all ~30 secrets from .env (was only 8) plus KEYCLOAK_ENABLED, LLAMASTACK_ENABLED, LANGFUSE_ENABLED flags
- Update Makefile: deploy-dev uses `-f values-dev.yaml`, remove stale migration job cleanup from undeploy

Stacked on #85. Final PR in the F23 Helm chart completion series.

## Test plan
- [x] `helm lint` passes with default values
- [x] `helm lint` passes with values-dev.yaml overlay
- [x] Dev overlay disables keycloak (0 keycloak resources rendered)
- [x] Dev overlay sets AUTH_DISABLED=true (verified base64 decode)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>