### PR TITLE
fix(api): make safety output checks fail-closed instead of fail-open

### DIFF
--- a/packages/api/src/inference/safety.py
+++ b/packages/api/src/inference/safety.py
@@ -6,9 +6,9 @@ inputs and agent outputs against 13 safety categories (S1-S13).  The same
 ChatOpenAI infrastructure used for inference models is reused here.
 
 Design principle: shields ON by default when SAFETY_MODEL is set, degrade
-gracefully (no-op + warning) when not configured.  Input checks fail-closed
-(block on error) to prevent unsafe content from reaching the system. Output
-checks fail-open (allow on error) so transient outages don't block responses.
+gracefully (no-op + warning) when not configured.  Both input and output
+checks fail-closed (block on error) -- in a regulated lending domain, the
+risk of delivering an unverified response outweighs transient availability.
 """
 
 import logging
@@ -178,10 +178,8 @@ class SafetyChecker:
             response = await self._llm.ainvoke(prompt)
             return self._parse_response(response.content)
         except Exception:
-            logger.warning(
-                "Safety output check failed, treating as safe (fail-open)", exc_info=True
-            )
-            return SafetyResult(is_safe=True, explanation="Check failed, fail-open")
+            logger.error("Safety output check failed, blocking output (fail-closed)", exc_info=True)
+            return SafetyResult(is_safe=False, explanation="Safety check unavailable")
 
 
 _checker_instance: SafetyChecker | None = None

--- a/packages/api/tests/test_safety.py
+++ b/packages/api/tests/test_safety.py
@@ -47,7 +47,7 @@ def test_parse_empty_response_treated_as_safe():
     assert result.is_safe is True
 
 
-# -- Failure behavior (input=fail-closed, output=fail-open) --
+# -- Failure behavior (both fail-closed) --
 
 
 @pytest.mark.asyncio
@@ -65,8 +65,8 @@ async def test_input_check_fails_closed_on_llm_error():
 
 
 @pytest.mark.asyncio
-async def test_output_check_fails_open_on_llm_error():
-    """should return is_safe=True when output check errors."""
+async def test_output_check_fails_closed_on_llm_error():
+    """should return is_safe=False when output check errors (fail-closed)."""
     mock_llm = AsyncMock()
     mock_llm.ainvoke.side_effect = RuntimeError("timeout")
 
@@ -74,7 +74,8 @@ async def test_output_check_fails_open_on_llm_error():
     checker._llm = mock_llm
 
     result = await checker.check_output("q", "a")
-    assert result.is_safe is True
+    assert result.is_safe is False
+    assert result.explanation == "Safety check unavailable"
 
 
 # -- Prompt formatting (verify correct template is used) --


### PR DESCRIPTION
## Summary
- Safety output checks now fail-closed (block on error) instead of fail-open, matching input check behavior
- In a regulated lending domain, delivering an unverified LLM response is riskier than a transient "try again" error
- Addresses deferred review item D12 from Phase 1 review

## Test plan
- [x] `test_output_check_fails_closed_on_llm_error` updated to assert `is_safe=False`
- [x] All 12 safety tests pass
- [x] Full suite (989 tests) unaffected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>