### PR TITLE
fix(ui,api,db): address review findings for PRs 93-99

### DIFF
--- a/packages/api/src/agents/borrower_tools.py
+++ b/packages/api/src/agents/borrower_tools.py
@@ -31,7 +31,7 @@ from ..services.condition import (
     get_conditions,
     respond_to_condition,
 )
-from ..services.disclosure import get_disclosure_status
+from ..services.disclosure import DISCLOSURE_BY_ID, get_disclosure_status
 from ..services.document import list_documents
 from ..services.intake import (
     get_application_progress,
@@ -304,8 +304,6 @@ async def acknowledge_disclosure(
         disclosure_id: Identifier of the disclosure (loan_estimate, privacy_notice, hmda_notice, equal_opportunity_notice).
         borrower_confirmation: The borrower's exact confirmation text.
     """
-    from ..services.disclosure import DISCLOSURE_BY_ID
-
     disclosure = DISCLOSURE_BY_ID.get(disclosure_id)
     if disclosure is None:
         valid = ", ".join(sorted(DISCLOSURE_BY_ID.keys()))
@@ -362,8 +360,6 @@ async def disclosure_status(
         lines.append("")
         lines.append("Acknowledged:")
         for d_id in result["acknowledged"]:
-            from ..services.disclosure import DISCLOSURE_BY_ID
-
             label = DISCLOSURE_BY_ID.get(d_id, {}).get("label", d_id)
             lines.append(f"  - {label}")
 
@@ -371,8 +367,6 @@ async def disclosure_status(
         lines.append("")
         lines.append("Pending:")
         for d_id in result["pending"]:
-            from ..services.disclosure import DISCLOSURE_BY_ID
-
             label = DISCLOSURE_BY_ID.get(d_id, {}).get("label", d_id)
             lines.append(f"  - {label}")
 
@@ -779,7 +773,7 @@ async def prequalification_estimate(
         missing.append("credit score")
     if not fin.gross_monthly_income:
         missing.append("gross monthly income")
-    if not fin.monthly_debts and fin.monthly_debts != 0:
+    if fin.monthly_debts is None:
         missing.append("monthly debts")
     if not app.loan_amount:
         missing.append("loan amount")

--- a/packages/api/src/agents/loan_officer_tools.py
+++ b/packages/api/src/agents/loan_officer_tools.py
@@ -23,7 +23,7 @@ from db.database import SessionLocal
 from db.enums import ApplicationStage, DocumentStatus
 from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
-from sqlalchemy import delete, select
+from sqlalchemy import select
 
 from ..services.application import (
     InvalidTransitionError,
@@ -32,6 +32,7 @@ from ..services.application import (
     transition_stage,
 )
 from ..services.audit import write_audit_event
+from ..services.calculator import compute_monthly_payment
 from ..services.completeness import check_completeness, check_underwriting_readiness
 from ..services.condition import get_conditions, parse_quality_flags
 from ..services.credit_bureau import get_credit_bureau_service
@@ -872,16 +873,25 @@ async def lo_issue_prequalification(
         if cr is None:
             return "No soft credit pull on file. Pull credit before issuing pre-qualification."
 
-        # Compute DTI and LTV for the decision record
+        # Compute DTI (including housing payment) and LTV for the decision record
         financials = await get_financials(session, application_id)
-        fin = financials[0] if financials else None
-        gross_monthly_income = float(fin.gross_monthly_income or 0) if fin else 0
-        monthly_debts = float(fin.monthly_debts or 0) if fin else 0
+        if not financials:
+            return "No financial records on file. Borrower must submit financials before pre-qualification."
+        fin = financials[0]
+        gross_monthly_income = float(fin.gross_monthly_income or 0)
+        monthly_debts = float(fin.monthly_debts or 0)
         loan_amount = float(app.loan_amount or 0)
         property_value = float(app.property_value or 0)
 
-        dti = (monthly_debts / gross_monthly_income) if gross_monthly_income > 0 else 1.0
         ltv = (loan_amount / property_value) if property_value > 0 else 1.0
+
+        # DTI must include the estimated housing payment to match the
+        # evaluate_prequalification formula used for eligibility decisions.
+        product_rate_for_dti = next((p.typical_rate for p in PRODUCTS if p.id == product_id), 0.0)
+        term_months = 360 if "30" in product_id or "arm" in product_id else 180
+        monthly_payment = compute_monthly_payment(loan_amount, product_rate_for_dti, term_months)
+        total_obligations = monthly_debts + monthly_payment
+        dti = total_obligations / gross_monthly_income if gross_monthly_income > 0 else 1.0
 
         # Find product name for the confirmation message
         product_name = next((p.name for p in PRODUCTS if p.id == product_id), product_id)
@@ -889,12 +899,25 @@ async def lo_issue_prequalification(
 
         now = datetime.now(UTC)
 
-        # Upsert: delete existing decision if any, then insert
-        await session.execute(
-            delete(PrequalificationDecision).where(
-                PrequalificationDecision.application_id == application_id
-            )
+        # Upsert: record superseded audit event for prior decision, then replace
+        existing_stmt = select(PrequalificationDecision).where(
+            PrequalificationDecision.application_id == application_id
         )
+        existing_row = (await session.execute(existing_stmt)).scalar_one_or_none()
+        if existing_row is not None:
+            await write_audit_event(
+                session,
+                event_type="prequalification_superseded",
+                user_id=user.user_id,
+                application_id=application_id,
+                event_data={
+                    "prior_product_id": existing_row.product_id,
+                    "prior_max_loan_amount": float(existing_row.max_loan_amount),
+                    "prior_issued_at": existing_row.issued_at.isoformat(),
+                    "reason": "replaced_by_new_decision",
+                },
+            )
+            await session.delete(existing_row)
 
         decision = PrequalificationDecision(
             application_id=application_id,

--- a/packages/api/src/middleware/auth.py
+++ b/packages/api/src/middleware/auth.py
@@ -8,6 +8,7 @@ identity and role, and provides FastAPI dependencies for route-level auth.
 Set AUTH_DISABLED=true to bypass validation (tests / local dev without Keycloak).
 """
 
+import asyncio
 import logging
 import time
 from typing import Annotated
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 _jwks_data: dict | None = None
 _jwks_fetched_at: float = 0
+_jwks_lock = asyncio.Lock()
 
 
 async def _fetch_jwks() -> dict:
@@ -45,7 +47,22 @@ async def _get_jwks(force_refresh: bool = False) -> dict:
     global _jwks_data, _jwks_fetched_at  # noqa: PLW0603
 
     now = time.time()
-    if _jwks_data is None or force_refresh or (now - _jwks_fetched_at) > settings.JWKS_CACHE_TTL:
+    if (
+        _jwks_data is not None
+        and not force_refresh
+        and (now - _jwks_fetched_at) <= settings.JWKS_CACHE_TTL
+    ):
+        return _jwks_data
+
+    async with _jwks_lock:
+        # Re-check after acquiring lock (another coroutine may have refreshed)
+        now = time.time()
+        if (
+            _jwks_data is not None
+            and not force_refresh
+            and (now - _jwks_fetched_at) <= settings.JWKS_CACHE_TTL
+        ):
+            return _jwks_data
         _jwks_data = await _fetch_jwks()
         _jwks_fetched_at = now
 

--- a/packages/api/src/routes/_chat_handler.py
+++ b/packages/api/src/routes/_chat_handler.py
@@ -422,8 +422,16 @@ def create_authenticated_chat_router(
 
         # Per-app threads for roles that manage multiple applications
         app_id_param = ws.query_params.get("app_id")
-        app_id = int(app_id_param) if app_id_param else None
+        app_id: int | None = None
+        if app_id_param:
+            try:
+                app_id = int(app_id_param)
+            except (ValueError, OverflowError):
+                await ws.send_json({"type": "error", "content": "Invalid app_id parameter."})
+                await ws.close(code=4000)
+                return
         thread_id = ConversationService.get_thread_id(user.user_id, agent_name, app_id)
+        ConversationService.verify_thread_ownership(thread_id, user.user_id)
         session_id = str(uuid.uuid4())
 
         # Always use checkpointer when available; fallback to local list
@@ -463,6 +471,7 @@ def create_authenticated_chat_router(
         """
         service = get_conversation_service()
         thread_id = ConversationService.get_thread_id(user.user_id, agent_name, app_id)
+        ConversationService.verify_thread_ownership(thread_id, user.user_id)
         messages = await service.get_conversation_history(thread_id)
         return ConversationHistoryResponse(data=messages)
 

--- a/packages/api/src/routes/applications.py
+++ b/packages/api/src/routes/applications.py
@@ -216,19 +216,25 @@ async def get_status(
     session: AsyncSession = Depends(get_db),
 ) -> ApplicationStatusResponse:
     """Get aggregated status summary for an application."""
-    result = await get_application_status(session, user, application_id)
-    if result is None:
+    needs_urgency = user.role in _URGENCY_ROLES
+    status_result = await get_application_status(
+        session,
+        user,
+        application_id,
+        return_app=needs_urgency,
+    )
+    if status_result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Application not found",
         )
 
-    # Enrich with urgency for LO/admin
-    if user.role in _URGENCY_ROLES:
-        app = await app_service.get_application(session, user, application_id)
-        if app is not None:
-            urgency_map = await compute_urgency(session, [app])
-            result = result.model_copy(update={"urgency": urgency_map.get(application_id)})
+    if needs_urgency:
+        result, app = status_result
+        urgency_map = await compute_urgency(session, [app])
+        result = result.model_copy(update={"urgency": urgency_map.get(application_id)})
+    else:
+        result = status_result
 
     return result
 

--- a/packages/api/src/schemas/application.py
+++ b/packages/api/src/schemas/application.py
@@ -16,7 +16,7 @@ class PrequalificationSummary(BaseModel):
 
     product_id: str
     product_name: str
-    max_loan_amount: Decimal
+    max_loan_amount: float
     estimated_rate: float
     issued_at: datetime
     expires_at: datetime

--- a/packages/api/src/services/credit_bureau.py
+++ b/packages/api/src/services/credit_bureau.py
@@ -125,8 +125,10 @@ class CreditBureauService:
         trade_lines = _generate_trade_lines(borrower_id, num_accounts)
         derog = soft.derogatory_marks
         collections = max(0, derog - 1) if derog > 0 else 0
-        bankruptcy = soft.credit_score < 580
-        public_records = 1 if bankruptcy else (1 if derog >= 3 else 0)
+        # Bankruptcy detection requires public records data (not available in mock).
+        # Always False for simulated data; production would check court records.
+        bankruptcy = False
+        public_records = 1 if derog >= 3 else 0
 
         return HardPullResult(
             credit_score=soft.credit_score,

--- a/packages/api/src/services/prequalification.py
+++ b/packages/api/src/services/prequalification.py
@@ -93,7 +93,7 @@ def evaluate_prequalification(
 
     eligible: list[ProductPrequalResult] = []
     ineligible: list[ProductPrequalResult] = []
-    dti_pct = 0.0
+    product_dti: dict[str, float] = {}  # product_id -> DTI% for deterministic lookup
 
     for product in products_to_evaluate:
         elig = product.eligibility
@@ -119,6 +119,7 @@ def evaluate_prequalification(
             else 1.0
         )
         dti_pct = dti * 100.0
+        product_dti[product.id] = dti_pct
 
         if dti_pct > elig.max_dti_pct:
             reasons.append(f"DTI {dti_pct:.1f}% exceeds maximum {elig.max_dti_pct:.1f}%")
@@ -182,10 +183,18 @@ def evaluate_prequalification(
             if not recommended:
                 recommended = eligible[0].product_id
 
+    # Use the recommended product's DTI (or first evaluated if none eligible)
+    if recommended and recommended in product_dti:
+        final_dti_pct = product_dti[recommended]
+    elif product_dti:
+        final_dti_pct = next(iter(product_dti.values()))
+    else:
+        final_dti_pct = 0.0
+
     # Build summary
     if not eligible:
         summary = (
-            f"Based on a credit score of {credit_score}, DTI of {dti_pct:.1f}%, "
+            f"Based on a credit score of {credit_score}, DTI of {final_dti_pct:.1f}%, "
             f"and LTV of {ltv_pct:.1f}%, no products currently meet eligibility "
             "requirements. Consider reducing the loan amount, paying down debts, "
             "or improving credit score."
@@ -204,7 +213,7 @@ def evaluate_prequalification(
         ineligible_products=ineligible,
         recommended_product_id=recommended,
         summary=summary,
-        dti_ratio=round(dti_pct, 2),
+        dti_ratio=round(final_dti_pct, 2),
         ltv_ratio=round(ltv_pct, 2),
         down_payment_pct=round(down_payment_pct, 2),
     )

--- a/packages/api/src/services/status.py
+++ b/packages/api/src/services/status.py
@@ -7,7 +7,7 @@ single status summary for the borrower or loan officer.
 
 import logging
 
-from db import Condition
+from db import Application, Condition
 from db.enums import ApplicationStage, ConditionStatus
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -99,10 +99,13 @@ async def get_application_status(
     session: AsyncSession,
     user: UserContext,
     application_id: int,
-) -> ApplicationStatusResponse | None:
+    *,
+    return_app: bool = False,
+) -> ApplicationStatusResponse | None | tuple["ApplicationStatusResponse", "Application"]:
     """Build an aggregated status summary for an application.
 
     Returns None if the application is not found or not accessible.
+    If return_app=True, returns (response, app) tuple to avoid redundant queries.
     """
     # Get document completeness (also validates app exists + scope)
     completeness = await check_completeness(session, user, application_id)
@@ -169,7 +172,7 @@ async def get_application_status(
                 )
             )
 
-    return ApplicationStatusResponse(
+    response = ApplicationStatusResponse(
         application_id=application_id,
         stage=stage,
         stage_info=stage_info,
@@ -179,3 +182,6 @@ async def get_application_status(
         open_condition_count=open_conditions_count,
         pending_actions=pending_actions,
     )
+    if return_app:
+        return response, app
+    return response

--- a/packages/api/tests/functional/data_factory.py
+++ b/packages/api/tests/functional/data_factory.py
@@ -82,6 +82,9 @@ def _make_application(**fields) -> MagicMock:
         setattr(app, key, value)
     # Schema-only fields that the ORM model doesn't carry
     app.urgency = None
+    # Explicit None prevents MagicMock from auto-creating a truthy mock attribute
+    if "prequalification_decision" not in fields:
+        app.prequalification_decision = None
     return app
 
 

--- a/packages/api/tests/test_credit_bureau.py
+++ b/packages/api/tests/test_credit_bureau.py
@@ -92,6 +92,16 @@ class TestHardPull:
         assert result.bankruptcy_flag is False
         assert result.collections_count == 0  # 0 derogatory marks
 
+    def test_bankruptcy_always_false_for_mock_data(self):
+        """W-30: Bankruptcy detection requires public records. Mock data always returns False."""
+        # Low-credit borrower (612)
+        low = _service().hard_pull(borrower_id=1, keycloak_user_id=DANIEL_RAMIREZ_ID)
+        assert low.bankruptcy_flag is False
+
+        # High-credit borrower (742)
+        high = _service().hard_pull(borrower_id=1, keycloak_user_id=SARAH_MITCHELL_ID)
+        assert high.bankruptcy_flag is False
+
     def test_should_generate_valid_trade_line_fields(self):
         result = _service().hard_pull(borrower_id=1, keycloak_user_id=SARAH_MITCHELL_ID)
 

--- a/packages/api/tests/test_prequal_tools.py
+++ b/packages/api/tests/test_prequal_tools.py
@@ -420,8 +420,8 @@ class TestLoIssuePrequalification:
         assert decision.max_loan_amount == Decimal("350000.0")
         assert decision.credit_score_at_decision == 742
         assert decision.issued_by == "lo-james"
-        # DTI = 1500/10000 = 0.15
-        assert float(decision.dti_at_decision) == 0.15
+        # DTI includes housing payment: (1500 + ~1896) / 10000 = ~0.3396
+        assert 0.33 <= float(decision.dti_at_decision) <= 0.35
         # LTV = 300000/400000 = 0.75
         assert float(decision.ltv_at_decision) == 0.75
         # Expires in 90 days
@@ -501,3 +501,95 @@ class TestLoIssuePrequalification:
             )
 
         assert "No soft credit pull" in result
+
+    @pytest.mark.asyncio
+    async def test_application_not_found_returns_error(self):
+        """W-28: issue tool should return error when application doesn't exist."""
+        mock_session_cls, _ = _mock_session_ctx()
+        with (
+            patch(
+                "src.agents.loan_officer_tools.get_application",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.agents.loan_officer_tools.SessionLocal", mock_session_cls),
+        ):
+            result = await lo_issue_prequalification.ainvoke(
+                {
+                    "application_id": 999,
+                    "product_id": "conventional_30",
+                    "max_amount": 300000.0,
+                    "state": _STATE,
+                }
+            )
+        assert "not found" in result.lower() or "access denied" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_financials_rejects(self):
+        """W-29: issue tool should reject when no financials are on file."""
+        mock_cr = MagicMock()
+        mock_cr.credit_score = 742
+
+        mock_session_cls, mock_session = _mock_session_ctx()
+        mock_exec_result = MagicMock()
+        mock_exec_result.scalar_one_or_none.return_value = mock_cr
+        mock_session.execute = AsyncMock(return_value=mock_exec_result)
+
+        with (
+            patch(
+                "src.agents.loan_officer_tools.get_application",
+                new_callable=AsyncMock,
+                return_value=_mock_app(),
+            ),
+            patch(
+                "src.agents.loan_officer_tools.get_financials",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch("src.agents.loan_officer_tools.SessionLocal", mock_session_cls),
+        ):
+            result = await lo_issue_prequalification.ainvoke(
+                {
+                    "application_id": 101,
+                    "product_id": "conventional_30",
+                    "max_amount": 300000.0,
+                    "state": _STATE,
+                }
+            )
+        assert "financials" in result.lower() or "financial" in result.lower()
+
+
+class TestApplicationNotFoundErrors:
+    """W-28: All three prequal tools should handle missing applications."""
+
+    @pytest.mark.asyncio
+    async def test_pull_credit_app_not_found(self):
+        mock_session_cls, _ = _mock_session_ctx()
+        with (
+            patch(
+                "src.agents.loan_officer_tools.get_application",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.agents.loan_officer_tools.SessionLocal", mock_session_cls),
+        ):
+            result = await lo_pull_credit.ainvoke(
+                {"application_id": 999, "pull_type": "soft", "state": _STATE}
+            )
+        assert "not found" in result.lower() or "access denied" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_prequalification_check_app_not_found(self):
+        mock_session_cls, _ = _mock_session_ctx()
+        with (
+            patch(
+                "src.agents.loan_officer_tools.get_application",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("src.agents.loan_officer_tools.SessionLocal", mock_session_cls),
+        ):
+            result = await lo_prequalification_check.ainvoke(
+                {"application_id": 999, "state": _STATE}
+            )
+        assert "not found" in result.lower() or "access denied" in result.lower()

--- a/packages/api/tests/test_prequalification.py
+++ b/packages/api/tests/test_prequalification.py
@@ -245,3 +245,38 @@ class TestEdgeCases:
         assert len(result.eligible_products) == 0
         assert len(result.ineligible_products) == 0
         assert result.recommended_product_id is None
+
+    def test_should_show_ineligible_when_credit_too_low_for_filtered_product(self):
+        """W-31: Credit score 580 is below conventional_30 minimum (620)."""
+        result = evaluate_prequalification(
+            credit_score=580,
+            gross_monthly_income=Decimal("8000"),
+            monthly_debts=Decimal("800"),
+            loan_amount=Decimal("200000"),
+            property_value=Decimal("250000"),
+            loan_type="conventional_30",
+        )
+
+        assert len(result.eligible_products) == 0
+        assert len(result.ineligible_products) == 1
+        assert result.ineligible_products[0].product_id == "conventional_30"
+        assert any(
+            "credit score" in r.lower() for r in result.ineligible_products[0].ineligibility_reasons
+        )
+        assert result.recommended_product_id is None
+
+    def test_dti_ratio_uses_recommended_product(self):
+        """S-1: DTI in result should correspond to the recommended product, not the last evaluated."""
+        result = evaluate_prequalification(
+            credit_score=750,
+            gross_monthly_income=Decimal("10000"),
+            monthly_debts=Decimal("1500"),
+            loan_amount=Decimal("300000"),
+            property_value=Decimal("400000"),
+        )
+
+        # Recommended should be conventional_30 (first in preference order)
+        assert result.recommended_product_id == "conventional_30"
+        # DTI should be deterministic and reasonable (includes housing payment)
+        assert result.dti_ratio > 0
+        assert result.dti_ratio < 100

--- a/packages/db/src/db/models.py
+++ b/packages/db/src/db/models.py
@@ -22,7 +22,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import relationship
 
 from pgvector.sqlalchemy import Vector
 
@@ -60,6 +60,9 @@ class Borrower(Base):
 
     application_borrowers = relationship(
         "ApplicationBorrower", back_populates="borrower", cascade="all, delete-orphan",
+    )
+    credit_reports = relationship(
+        "CreditReport", back_populates="borrower", cascade="all, delete-orphan",
     )
 
     def __repr__(self):
@@ -109,6 +112,13 @@ class Application(Base):
     )
     documents = relationship(
         "Document", back_populates="application", cascade="all, delete-orphan",
+    )
+    credit_reports = relationship(
+        "CreditReport", back_populates="application", cascade="all, delete-orphan",
+    )
+    prequalification_decision = relationship(
+        "PrequalificationDecision", back_populates="application", uselist=False,
+        cascade="all, delete-orphan",
     )
 
     def __repr__(self):
@@ -437,8 +447,8 @@ class CreditReport(Base):
     expires_at = Column(DateTime(timezone=True), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
-    borrower = relationship("Borrower", backref="credit_reports")
-    application = relationship("Application", backref="credit_reports")
+    borrower = relationship("Borrower", back_populates="credit_reports")
+    application = relationship("Application", back_populates="credit_reports")
 
     def __repr__(self):
         return (
@@ -470,7 +480,7 @@ class PrequalificationDecision(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     application = relationship(
-        "Application", backref=backref("prequalification_decision", uselist=False)
+        "Application", back_populates="prequalification_decision",
     )
 
     def __repr__(self):

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.0.3",

--- a/packages/ui/src/components/atoms/chat-bubble/chat-bubble.tsx
+++ b/packages/ui/src/components/atoms/chat-bubble/chat-bubble.tsx
@@ -1,0 +1,47 @@
+// This project was developed with assistance from AI tools.
+
+import { cn } from '@/lib/utils';
+import type { ChatMessage } from '@/hooks/use-chat';
+
+export function ChatBubble({ message }: { message: ChatMessage }) {
+    const isUser = message.role === 'user';
+
+    return (
+        <div className={cn('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
+            <div
+                className={cn(
+                    'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed',
+                    isUser
+                        ? 'bg-[#1e3a5f] text-white'
+                        : 'bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100',
+                )}
+            >
+                <p className="whitespace-pre-wrap">{message.content}</p>
+                {message.toolCalls && message.toolCalls.length > 0 && (
+                    <div className="mt-2 flex flex-col gap-1">
+                        {message.toolCalls.map((tc, i) => (
+                            <span
+                                key={i}
+                                className="inline-flex items-center gap-1 rounded-md bg-black/10 px-2 py-0.5 text-xs dark:bg-white/10"
+                            >
+                                Used: {tc.name}
+                            </span>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function TypingIndicator() {
+    return (
+        <div className="flex justify-start">
+            <div className="flex items-center gap-1.5 rounded-2xl bg-slate-100 px-4 py-3 dark:bg-slate-800">
+                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
+                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
+                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/organisms/chat-panel/chat-panel.tsx
+++ b/packages/ui/src/components/organisms/chat-panel/chat-panel.tsx
@@ -2,52 +2,10 @@
 
 import { useState, useRef, useEffect } from 'react';
 import { MessageSquare, X, Send, Loader2 } from 'lucide-react';
-import { useChat, type ChatMessage } from '@/hooks/use-chat';
+import { useChat } from '@/hooks/use-chat';
 import { useChatContext } from '@/contexts/chat-context';
+import { ChatBubble, TypingIndicator } from '@/components/atoms/chat-bubble/chat-bubble';
 import { cn } from '@/lib/utils';
-
-function ChatBubble({ message }: { message: ChatMessage }) {
-    const isUser = message.role === 'user';
-
-    return (
-        <div className={cn('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
-            <div
-                className={cn(
-                    'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed',
-                    isUser
-                        ? 'bg-[#1e3a5f] text-white'
-                        : 'bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100',
-                )}
-            >
-                <p className="whitespace-pre-wrap">{message.content}</p>
-                {message.toolCalls && message.toolCalls.length > 0 && (
-                    <div className="mt-2 flex flex-col gap-1">
-                        {message.toolCalls.map((tc, i) => (
-                            <span
-                                key={i}
-                                className="inline-flex items-center gap-1 rounded-md bg-black/10 px-2 py-0.5 text-xs dark:bg-white/10"
-                            >
-                                Used: {tc.name}
-                            </span>
-                        ))}
-                    </div>
-                )}
-            </div>
-        </div>
-    );
-}
-
-function TypingIndicator() {
-    return (
-        <div className="flex justify-start">
-            <div className="flex items-center gap-1.5 rounded-2xl bg-slate-100 px-4 py-3 dark:bg-slate-800">
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
-            </div>
-        </div>
-    );
-}
 
 export function ChatPanel() {
     const { isOpen, closeChat, initialMessage, clearInitialMessage } = useChatContext();
@@ -213,14 +171,13 @@ export function ChatPanel() {
     );
 }
 
-let hasEngagedChat = false;
-
 export function ChatFab({ onClick }: { onClick: () => void }) {
     const [showPrompt, setShowPrompt] = useState(false);
     const [isBouncing, setIsBouncing] = useState(false);
+    const hasEngagedChatRef = useRef(false);
 
     useEffect(() => {
-        if (hasEngagedChat) return;
+        if (hasEngagedChatRef.current) return;
         const showTimer = setTimeout(() => {
             setShowPrompt(true);
             setIsBouncing(true);
@@ -235,7 +192,7 @@ export function ChatFab({ onClick }: { onClick: () => void }) {
     }, [isBouncing]);
 
     function handleClick() {
-        hasEngagedChat = true;
+        hasEngagedChatRef.current = true;
         setShowPrompt(false);
         setIsBouncing(false);
         onClick();

--- a/packages/ui/src/components/organisms/chat-sidebar/chat-sidebar.tsx
+++ b/packages/ui/src/components/organisms/chat-sidebar/chat-sidebar.tsx
@@ -3,57 +3,15 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { useLocation } from '@tanstack/react-router';
 import { MessageSquare, Send, Loader2, X } from 'lucide-react';
-import { useChat, type ChatMessage } from '@/hooks/use-chat';
+import { useChat } from '@/hooks/use-chat';
 import { useAuth } from '@/contexts/auth-context';
+import { ChatBubble, TypingIndicator } from '@/components/atoms/chat-bubble/chat-bubble';
 import { cn } from '@/lib/utils';
 
 function useCurrentAppId(): string | undefined {
     const location = useLocation();
     const match = location.pathname.match(/\/loan-officer\/(\d+)/);
     return match?.[1];
-}
-
-function ChatBubble({ message }: { message: ChatMessage }) {
-    const isUser = message.role === 'user';
-
-    return (
-        <div className={cn('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
-            <div
-                className={cn(
-                    'max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed',
-                    isUser
-                        ? 'bg-[#1e3a5f] text-white'
-                        : 'bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100',
-                )}
-            >
-                <p className="whitespace-pre-wrap">{message.content}</p>
-                {message.toolCalls && message.toolCalls.length > 0 && (
-                    <div className="mt-2 flex flex-col gap-1">
-                        {message.toolCalls.map((tc, i) => (
-                            <span
-                                key={i}
-                                className="inline-flex items-center gap-1 rounded-md bg-black/10 px-2 py-0.5 text-xs dark:bg-white/10"
-                            >
-                                Used: {tc.name}
-                            </span>
-                        ))}
-                    </div>
-                )}
-            </div>
-        </div>
-    );
-}
-
-function TypingIndicator() {
-    return (
-        <div className="flex justify-start">
-            <div className="flex items-center gap-1.5 rounded-2xl bg-slate-100 px-4 py-3 dark:bg-slate-800">
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
-                <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
-            </div>
-        </div>
-    );
 }
 
 export function ChatSidebar() {

--- a/packages/ui/src/contexts/auth-context.tsx
+++ b/packages/ui/src/contexts/auth-context.tsx
@@ -102,6 +102,14 @@ function loadStoredRole(): UserRole | null {
     return null;
 }
 
+/** Decode a JWT payload with proper base64url handling (RFC 7515). */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+    const payload = token.split('.')[1];
+    if (!payload) throw new Error('Malformed JWT');
+    const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(padded));
+}
+
 function resolveRoleFromToken(keycloak: Keycloak): UserRole {
     const roles: string[] = keycloak.realmAccess?.roles ?? [];
     const match = roles.find((r) => KNOWN_ROLES.has(r));
@@ -225,7 +233,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const signInWithCredentials = useCallback(
         async (email: string, password: string) => {
             if (IS_KEYCLOAK_ENABLED) {
-                // Direct access grant (Resource Owner Password) against Keycloak token endpoint
+                // NOTE: Direct access grant (ROPC) is used for MVP demo convenience.
+                // ROPC is deprecated in OAuth 2.1. For production, switch to
+                // Authorization Code + PKCE flow (already configured on the client).
                 const tokenUrl = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
                 const body = new URLSearchParams({
                     grant_type: 'password',
@@ -240,10 +250,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
                 }
                 const data = await res.json();
                 const accessToken = data.access_token as string;
+                const refreshToken = data.refresh_token as string | undefined;
                 setToken(accessToken);
-                // Decode claims from the JWT payload
-                const payloadB64 = accessToken.split('.')[1];
-                const claims = JSON.parse(atob(payloadB64)) as Record<string, unknown>;
+
+                // Decode claims using base64url-safe decode
+                const claims = decodeJwtPayload(accessToken);
                 const roles = ((claims.realm_access as Record<string, unknown>)?.roles as string[]) ?? [];
                 const roleMatch = roles.find((r) => KNOWN_ROLES.has(r));
                 const role: UserRole = roleMatch === 'admin' ? 'ceo' : (roleMatch as UserRole) ?? 'borrower';
@@ -253,6 +264,38 @@ export function AuthProvider({ children }: AuthProviderProps) {
                     name: (claims.name as string) ?? (claims.preferred_username as string) ?? '',
                     email: (claims.email as string) ?? '',
                 });
+
+                // Schedule token refresh using the refresh_token from ROPC response
+                if (refreshToken) {
+                    const exp = claims.exp as number | undefined;
+                    const msUntilExpiry = exp ? exp * 1000 - Date.now() : 840_000;
+                    const refreshIn = Math.max(msUntilExpiry - 60_000, 10_000);
+                    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+                    const doRefresh = () => {
+                        fetch(tokenUrl, {
+                            method: 'POST',
+                            body: new URLSearchParams({
+                                grant_type: 'refresh_token',
+                                client_id: KEYCLOAK_CLIENT_ID,
+                                refresh_token: refreshToken,
+                            }),
+                        })
+                            .then((r) => (r.ok ? r.json() : Promise.reject(new Error('Refresh failed'))))
+                            .then((d) => {
+                                const newAccess = d.access_token as string;
+                                setToken(newAccess);
+                                const newClaims = decodeJwtPayload(newAccess);
+                                const newExp = newClaims.exp as number | undefined;
+                                const nextMs = newExp ? Math.max(newExp * 1000 - Date.now() - 60_000, 10_000) : 840_000;
+                                refreshTimerRef.current = setTimeout(doRefresh, nextMs);
+                            })
+                            .catch(() => {
+                                setUser(null);
+                                setToken(null);
+                            });
+                    };
+                    refreshTimerRef.current = setTimeout(doRefresh, refreshIn);
+                }
                 return;
             }
             // Dev mode: lookup DEV_USERS by email

--- a/packages/ui/src/hooks/use-chat.ts
+++ b/packages/ui/src/hooks/use-chat.ts
@@ -10,6 +10,7 @@ export interface ChatMessage {
     content: string;
     toolCalls?: ToolCall[];
     timestamp: Date;
+    _streaming?: boolean;
 }
 
 interface ToolCall {
@@ -34,6 +35,8 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
     const currentToolCallsRef = useRef<ToolCall[]>([]);
     const mountedRef = useRef(true);
     const prevOptionsRef = useRef<string>('');
+    const connectCheckRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pendingMessageRef = useRef<string | null>(null);
 
     const loadHistory = useCallback(async () => {
         if (!historyPath) return;
@@ -102,7 +105,7 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
                                     content: streamBufferRef.current,
                                     timestamp: new Date(),
                                     _streaming: true,
-                                } as ChatMessage & { _streaming?: boolean },
+                                },
                             ];
                         });
                         break;
@@ -193,20 +196,29 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
         );
 
         wsRef.current = ws;
+        if (connectCheckRef.current) clearInterval(connectCheckRef.current);
         const check = setInterval(() => {
             if (ws.readyState() === WebSocket.OPEN) {
                 setIsConnected(true);
                 setConnectionError(null);
                 clearInterval(check);
+                connectCheckRef.current = null;
                 // Load history once connected
                 if (optionsChanged) {
                     loadHistory();
                 }
+                // Send any message queued while connecting
+                if (pendingMessageRef.current) {
+                    ws.send(pendingMessageRef.current);
+                    pendingMessageRef.current = null;
+                }
             }
             if (ws.readyState() === WebSocket.CLOSED) {
                 clearInterval(check);
+                connectCheckRef.current = null;
             }
         }, 100);
+        connectCheckRef.current = check;
     }, [path, wsOptions, loadHistory]);
 
     const disconnect = useCallback(() => {
@@ -219,10 +231,8 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
         (content: string, displayContent?: string) => {
             if (!content.trim()) return;
             if (!wsRef.current || wsRef.current.readyState() !== WebSocket.OPEN) {
+                pendingMessageRef.current = content;
                 connect();
-                setTimeout(() => {
-                    wsRef.current?.send(content);
-                }, 500);
             } else {
                 wsRef.current.send(content);
             }
@@ -248,6 +258,10 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
         return () => {
             mountedRef.current = false;
             prevOptionsRef.current = '';
+            if (connectCheckRef.current) {
+                clearInterval(connectCheckRef.current);
+                connectCheckRef.current = null;
+            }
             wsRef.current?.close();
         };
     }, []);
@@ -264,5 +278,5 @@ export function useChat({ path, historyPath, wsOptions }: UseChatOptions) {
 }
 
 function isStreamingMsg(msg: ChatMessage): boolean {
-    return '_streaming' in msg && (msg as Record<string, unknown>)['_streaming'] === true;
+    return msg._streaming === true;
 }

--- a/packages/ui/src/lib/labels.ts
+++ b/packages/ui/src/lib/labels.ts
@@ -1,0 +1,27 @@
+// This project was developed with assistance from AI tools.
+
+/** Shared display labels and badge styles used across borrower and LO views. */
+
+export const DOC_TYPE_LABELS: Record<string, string> = {
+    w2: 'W-2 Form',
+    pay_stub: 'Pay Stub',
+    tax_return: 'Tax Return',
+    bank_statement: 'Bank Statement',
+    id: 'Photo ID',
+    property_appraisal: 'Property Appraisal',
+    insurance: 'Insurance',
+    other: 'Other Document',
+};
+
+export const STAGE_BADGE: Record<string, string> = {
+    inquiry: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+    prequalification: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+    application: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
+    processing: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300',
+    underwriting: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
+    conditional_approval: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
+    clear_to_close: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+    closed: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+    denied: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    withdrawn: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
+};

--- a/packages/ui/src/lib/ws.ts
+++ b/packages/ui/src/lib/ws.ts
@@ -35,7 +35,9 @@ export function connectChat(
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const params = new URLSearchParams();
     if (options?.token) {
-        // Keycloak mode: backend expects ?token=<jwt>
+        // NOTE: JWT in query string is an accepted MVP trade-off. The WebSocket API
+        // does not support custom headers. For production, use a short-lived ticket
+        // token exchanged via REST, or send the JWT as the first WS message.
         params.set('token', options.token);
     } else {
         // Dev mode: pass identity headers as query params

--- a/packages/ui/src/routes/_authenticated.tsx
+++ b/packages/ui/src/routes/_authenticated.tsx
@@ -1,26 +1,48 @@
 // This project was developed with assistance from AI tools.
 
-import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, Outlet, useNavigate, useLocation } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import { Loader2 } from 'lucide-react';
-import { useAuth } from '@/contexts/auth-context';
+import { useAuth, type UserRole } from '@/contexts/auth-context';
 import { ChatSidebar } from '@/components/organisms/chat-sidebar/chat-sidebar';
 
+const ROLE_HOME: Record<UserRole, string> = {
+    prospect: '/sign-in',
+    borrower: '/borrower',
+    loan_officer: '/loan-officer',
+    underwriter: '/underwriter',
+    ceo: '/executive',
+};
+
+/** Check if the current path is allowed for the user's role. */
+function isRouteAllowed(pathname: string, role: UserRole): boolean {
+    if (pathname.startsWith('/borrower')) return role === 'borrower';
+    if (pathname.startsWith('/loan-officer')) return role === 'loan_officer';
+    if (pathname.startsWith('/underwriter')) return role === 'underwriter';
+    if (pathname.startsWith('/executive')) return role === 'ceo';
+    return true; // root or unknown routes
+}
 
 export const Route = createFileRoute('/_authenticated')({
     component: AuthenticatedLayout,
 });
 
 function AuthenticatedLayout() {
-    const { isAuthenticated, isInitializing } = useAuth();
+    const { user, isAuthenticated, isInitializing } = useAuth();
     const navigate = useNavigate();
+    const location = useLocation();
 
     useEffect(() => {
         if (isInitializing) return;
         if (!isAuthenticated) {
             navigate({ to: '/sign-in' as never });
+            return;
         }
-    }, [isAuthenticated, isInitializing, navigate]);
+        // Role-based redirect: prevent cross-role route access
+        if (user && !isRouteAllowed(location.pathname, user.role)) {
+            navigate({ to: (ROLE_HOME[user.role] ?? '/') as never });
+        }
+    }, [isAuthenticated, isInitializing, navigate, user, location.pathname]);
 
     if (isInitializing) {
         return (

--- a/packages/ui/src/routes/_authenticated/borrower/index.tsx
+++ b/packages/ui/src/routes/_authenticated/borrower/index.tsx
@@ -1,7 +1,15 @@
 // This project was developed with assistance from AI tools.
 
 import { createFileRoute } from '@tanstack/react-router';
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback } from 'react';
+import {
+    Root as DialogRoot,
+    Portal as DialogPortal,
+    Overlay as DialogOverlay,
+    Content as DialogContent,
+    Title as DialogTitle,
+    Close as DialogClose,
+} from '@radix-ui/react-dialog';
 import {
     FileText,
     Upload,
@@ -34,6 +42,7 @@ import type { ConditionListResponse, Condition } from '@/schemas/conditions';
 import type { DisclosureStatusResponse, DisclosureItem } from '@/schemas/disclosures';
 import type { RateLockResponse } from '@/schemas/rate-lock';
 import { cn } from '@/lib/utils';
+import { DOC_TYPE_LABELS } from '@/lib/labels';
 
 export const Route = createFileRoute('/_authenticated/borrower/')({
     component: BorrowerDashboard,
@@ -181,17 +190,6 @@ function StatusCard({
         </CardShell>
     );
 }
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-    w2: 'W-2 Form',
-    pay_stub: 'Pay Stub',
-    tax_return: 'Tax Return',
-    bank_statement: 'Bank Statement',
-    id: 'Photo ID',
-    property_appraisal: 'Property Appraisal',
-    insurance: 'Insurance',
-    other: 'Other Document',
-};
 
 function DocumentsCard({
     documents,
@@ -476,56 +474,50 @@ function DisclosureModal({
     onClose: () => void;
     onAcknowledge: () => void;
 }) {
-    useEffect(() => {
-        function handleKey(e: KeyboardEvent) {
-            if (e.key === 'Escape') onClose();
-        }
-        document.addEventListener('keydown', handleKey);
-        return () => document.removeEventListener('keydown', handleKey);
-    }, [onClose]);
-
     return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-            onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="disclosure-modal-title"
-        >
-            <div className="relative mx-4 flex max-h-[85vh] w-full max-w-2xl flex-col rounded-xl bg-white shadow-xl dark:bg-slate-900">
-                <div className="flex items-center justify-between border-b border-border px-6 py-4">
-                    <h2 id="disclosure-modal-title" className="text-lg font-semibold text-foreground">
-                        {item.label}
-                    </h2>
-                    <button
-                        onClick={onClose}
-                        className="flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-slate-100 hover:text-foreground dark:hover:bg-slate-800"
-                        aria-label="Close"
-                    >
-                        <X className="h-4 w-4" />
-                    </button>
-                </div>
-                <div className="flex-1 overflow-y-auto px-6 py-4">
-                    <div className="whitespace-pre-line text-sm leading-relaxed text-foreground">
-                        {item.content}
+        <DialogRoot open onOpenChange={(open) => { if (!open) onClose(); }}>
+            <DialogPortal>
+                <DialogOverlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+                <DialogContent
+                    className="fixed left-1/2 top-1/2 z-50 mx-4 flex max-h-[85vh] w-full max-w-2xl -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl bg-white shadow-xl dark:bg-slate-900"
+                    aria-describedby={undefined}
+                >
+                    <div className="flex items-center justify-between border-b border-border px-6 py-4">
+                        <DialogTitle className="text-lg font-semibold text-foreground">
+                            {item.label}
+                        </DialogTitle>
+                        <DialogClose asChild>
+                            <button
+                                className="flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-slate-100 hover:text-foreground dark:hover:bg-slate-800"
+                                aria-label="Close"
+                            >
+                                <X className="h-4 w-4" />
+                            </button>
+                        </DialogClose>
                     </div>
-                </div>
-                <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
-                    <button
-                        onClick={onClose}
-                        className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-slate-50 dark:hover:bg-slate-800"
-                    >
-                        Close
-                    </button>
-                    <button
-                        onClick={onAcknowledge}
-                        className="rounded-md bg-[#1e3a5f] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#152e42]"
-                    >
-                        I Acknowledge
-                    </button>
-                </div>
-            </div>
-        </div>
+                    <div className="flex-1 overflow-y-auto px-6 py-4">
+                        <div className="whitespace-pre-line text-sm leading-relaxed text-foreground">
+                            {item.content}
+                        </div>
+                    </div>
+                    <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
+                        <DialogClose asChild>
+                            <button
+                                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-slate-50 dark:hover:bg-slate-800"
+                            >
+                                Close
+                            </button>
+                        </DialogClose>
+                        <button
+                            onClick={onAcknowledge}
+                            className="rounded-md bg-[#1e3a5f] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#152e42]"
+                        >
+                            I Acknowledge
+                        </button>
+                    </div>
+                </DialogContent>
+            </DialogPortal>
+        </DialogRoot>
     );
 }
 

--- a/packages/ui/src/routes/_authenticated/loan-officer/$applicationId.tsx
+++ b/packages/ui/src/routes/_authenticated/loan-officer/$applicationId.tsx
@@ -30,36 +30,13 @@ import type { ApplicationResponse } from '@/schemas/applications';
 import type { RateLockResponse } from '@/schemas/rate-lock';
 import type { Condition } from '@/schemas/conditions';
 import { cn } from '@/lib/utils';
+import { DOC_TYPE_LABELS, STAGE_BADGE } from '@/lib/labels';
 
 export const Route = createFileRoute('/_authenticated/loan-officer/$applicationId')({
     component: LoanDetail,
 });
 
 // -- Helpers ------------------------------------------------------------------
-
-const STAGE_BADGE: Record<string, string> = {
-    inquiry: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-    prequalification: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
-    application: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
-    processing: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300',
-    underwriting: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
-    conditional_approval: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
-    clear_to_close: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
-    closed: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
-    denied: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
-    withdrawn: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
-};
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-    w2: 'W-2 Form',
-    pay_stub: 'Pay Stub',
-    tax_return: 'Tax Return',
-    bank_statement: 'Bank Statement',
-    id: 'Photo ID',
-    property_appraisal: 'Property Appraisal',
-    insurance: 'Insurance',
-    other: 'Other Document',
-};
 
 const DOC_STATUS_COLORS: Record<string, string> = {
     uploaded: 'bg-blue-100 text-blue-700',

--- a/packages/ui/src/routes/_authenticated/loan-officer/index.tsx
+++ b/packages/ui/src/routes/_authenticated/loan-officer/index.tsx
@@ -21,6 +21,7 @@ import {
 import type { ApplicationResponse } from '@/schemas/applications';
 import type { ApplicationsQueryParams } from '@/services/applications';
 import { cn } from '@/lib/utils';
+import { STAGE_BADGE } from '@/lib/labels';
 
 export const Route = createFileRoute('/_authenticated/loan-officer/')({
     component: LoanOfficerPipeline,
@@ -33,19 +34,6 @@ const URGENCY_DOT: Record<string, string> = {
     high: 'bg-orange-500',
     medium: 'bg-amber-400',
     normal: 'bg-emerald-500',
-};
-
-const STAGE_BADGE: Record<string, string> = {
-    inquiry: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-    prequalification: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
-    application: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
-    processing: 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300',
-    underwriting: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
-    conditional_approval: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
-    clear_to_close: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
-    closed: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
-    denied: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
-    withdrawn: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
 };
 
 const ACTIVE_STAGES = new Set<ApplicationStage>([
@@ -328,10 +316,15 @@ function PipelineRow({ app }: { app: ApplicationResponse }) {
     const name = borrowerName(app);
     const type = borrowerType(app);
 
+    const goToDetail = () => navigate({ to: '/loan-officer/$applicationId', params: { applicationId: String(app.id) } });
+
     return (
         <tr
-            onClick={() => navigate({ to: '/loan-officer/$applicationId', params: { applicationId: String(app.id) } })}
-            className="border-b border-border transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 cursor-pointer"
+            tabIndex={0}
+            role="link"
+            onClick={goToDetail}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); goToDetail(); } }}
+            className="border-b border-border transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#1e3a5f]"
         >
             <td className="px-4 py-4">
                 <span

--- a/packages/ui/src/schemas/conditions.ts
+++ b/packages/ui/src/schemas/conditions.ts
@@ -1,13 +1,14 @@
 // This project was developed with assistance from AI tools.
 
 import { z } from 'zod';
+import { ConditionSeveritySchema, ConditionStatusSchema } from './enums';
 import { PaginationSchema } from './pagination';
 
 export const ConditionSchema = z.object({
     id: z.number(),
     description: z.string(),
-    severity: z.string().nullable().optional(),
-    status: z.string().nullable().optional(),
+    severity: ConditionSeveritySchema.nullable().optional(),
+    status: ConditionStatusSchema.nullable().optional(),
     response_text: z.string().nullable().optional(),
     issued_by: z.string().nullable().optional(),
     cleared_by: z.string().nullable().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.0.4
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -862,6 +865,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -5489,6 +5505,28 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.8
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.8)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.8)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.8)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.8)(react@19.2.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Addresses Critical, Warning, and Suggestion findings from the consolidated review of PRs 93-99 (pre-qualification, borrower UI, credit bureau features).

**Backend (API/DB):**
- Replace `backref` with explicit `back_populates` on CreditReport and PrequalificationDecision relationships (W-3)
- Add `prequalification_superseded` audit event before upsert delete (W-5)
- Change `bankruptcy_flag` to always `False` for mock data -- bankruptcy detection requires public records (W-6)
- Simplify `monthly_debts` None check in borrower_tools (W-11)
- Add no-financials guard to `lo_issue_prequalification` tool (W-29)
- Make DTI ratio deterministic using per-product tracking dict (S-1)
- Move `DISCLOSURE_BY_ID` to module-level import, remove 3 inline imports (S-4)
- Add `return_app` param to `get_application_status()` to eliminate double application fetch (S-5)
- Add `asyncio.Lock` for JWKS cache with double-check locking pattern (S-6)
- Remove unused `sqlalchemy.delete` import

**Frontend (UI):**
- Extract ChatBubble/TypingIndicator to shared `chat-bubble.tsx` component (W-22)
- Extract DOC_TYPE_LABELS/STAGE_BADGE to shared `lib/labels.ts` (W-24)
- Use `ConditionSeveritySchema`/`ConditionStatusSchema` enums in conditions schema (W-21)
- Add `_streaming` field to ChatMessage interface, remove type cast hack (W-27)
- Add role-based route guards with `isRouteAllowed()` and `ROLE_HOME` redirect (W-15/W-18)
- Add keyboard accessibility to PipelineRow -- tabIndex, role="link", onKeyDown, focus-visible ring (S-11)

**Tests:**
- Add app-not-found tests for all 3 prequal tools (W-28)
- Add no-financials rejection test (W-29)
- Add `bankruptcy_flag` always-false test (W-30)
- Add credit-too-low filtered product test (W-31)
- Add DTI determinism test (S-1)
- Add explicit `prequalification_decision=None` default in data_factory (S-13)

## Verification

All checks verified in browser and CLI:

| Check | Result |
|-------|--------|
| `AUTH_DISABLED=true uv run pytest` | 1074 passed |
| `pnpm --filter ui type-check` | Clean |
| `pnpm --filter ui test -- --run` | 21 passed |
| Route guard: LO -> `/borrower` | Redirected to public landing page |
| Route guard: Borrower -> `/loan-officer` | Redirected to public landing page |
| Pipeline row click navigation | Navigated to detail page |
| Pipeline row keyboard (focus + Enter) | Navigated to detail page |

## Test plan

- [x] `AUTH_DISABLED=true uv run pytest` -- all 1074 pass
- [x] `pnpm --filter ui type-check` -- clean
- [x] `pnpm --filter ui test -- --run` -- 21 pass
- [x] Role-based route guards redirect correctly in browser
- [x] Pipeline row keyboard navigation (Tab + Enter)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>