### PR TITLE
chore(docs): add MkDocs Material scaffold and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+# This project was developed with assistance from AI tools.
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: pip install mkdocs-material
+
+      - run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ test-results/
 blob-report/
 .playwright-mcp/
 
+# MkDocs
+site/
+
 # Database
 *.db
 *.sqlite

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# Summit Cap Financial
+
+**Multi-Agent Loan Origination -- Red Hat AI Quickstart**
+
+!!! note "Documentation in progress"
+    This documentation site is under active development.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,65 @@
+# This project was developed with assistance from AI tools.
+#
+# MkDocs configuration for Summit Cap Financial documentation.
+# Build locally: mkdocs serve
+# Deploy:        GitHub Actions (.github/workflows/docs.yml)
+
+site_name: Summit Cap Financial
+site_description: Multi-Agent Loan Origination - Red Hat AI Quickstart
+repo_url: https://github.com/jeremyary/multi-agent-loan-origination
+repo_name: jeremyary/multi-agent-loan-origination
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: red
+      accent: red
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: red
+      accent: red
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+# Navigation structure -- agents will populate pages under each section.
+# Add new pages here as they are created.
+nav:
+  - Home: index.md


### PR DESCRIPTION
## Summary

- Add MkDocs Material config (`mkdocs.yml`) with Red Hat red palette, dark mode, search, code copy
- Add placeholder `docs/index.md` landing page
- Add GitHub Actions workflow to build and deploy docs to GitHub Pages on push to main
- Add `site/` to `.gitignore`

Scaffold only -- no content. Doc-writing agents will populate pages next.

**After merge:** enable GitHub Pages in repo Settings > Pages > Source: GitHub Actions.

## Test plan

- [x] `mkdocs build --strict` succeeds locally

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>