### PR TITLE
fix(ui): show typing indicator while awaiting model response

### DIFF
--- a/packages/ui/src/components/atoms/chat-bubble/chat-bubble.tsx
+++ b/packages/ui/src/components/atoms/chat-bubble/chat-bubble.tsx
@@ -16,7 +16,15 @@ export function ChatBubble({ message }: { message: ChatMessage }) {
                         : 'bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100',
                 )}
             >
-                <p className="whitespace-pre-wrap">{message.content}</p>
+                {!isUser && message._streaming && !message.content ? (
+                    <div className="flex items-center gap-1.5 py-0.5">
+                        <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:0ms]" />
+                        <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:150ms]" />
+                        <span className="h-2 w-2 animate-bounce rounded-full bg-slate-400 [animation-delay:300ms]" />
+                    </div>
+                ) : (
+                    <p className="whitespace-pre-wrap">{message.content}</p>
+                )}
                 {message.toolCalls && message.toolCalls.length > 0 && (
                     <div className="mt-2 flex flex-col gap-1">
                         {message.toolCalls.map((tc, i) => (

--- a/packages/ui/src/components/organisms/chat-panel/chat-panel.tsx
+++ b/packages/ui/src/components/organisms/chat-panel/chat-panel.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useLayoutEffect } from 'react';
 import { MessageSquare, X, Send, Loader2 } from 'lucide-react';
 import { useChat } from '@/hooks/use-chat';
 import { useChatContext } from '@/contexts/chat-context';
-import { ChatBubble, TypingIndicator } from '@/components/atoms/chat-bubble/chat-bubble';
+import { ChatBubble } from '@/components/atoms/chat-bubble/chat-bubble';
 import { cn } from '@/lib/utils';
 
 export function ChatPanel() {
@@ -137,9 +137,6 @@ export function ChatPanel() {
                     <ChatBubble key={msg.id} message={msg} />
                 ))}
 
-                {isStreaming && messages[messages.length - 1]?.role !== 'assistant' && (
-                    <TypingIndicator />
-                )}
             </div>
 
             {/* Input */}
@@ -152,7 +149,6 @@ export function ChatPanel() {
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={handleKeyDown}
                         placeholder="Type your message..."
-                        disabled={isStreaming}
                         className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
                     />
                     <button

--- a/packages/ui/src/components/organisms/chat-sidebar/chat-sidebar.tsx
+++ b/packages/ui/src/components/organisms/chat-sidebar/chat-sidebar.tsx
@@ -5,7 +5,7 @@ import { useLocation } from '@tanstack/react-router';
 import { MessageSquare, Send, Loader2, X, Trash2 } from 'lucide-react';
 import { useChat } from '@/hooks/use-chat';
 import { useAuth } from '@/contexts/auth-context';
-import { ChatBubble, TypingIndicator } from '@/components/atoms/chat-bubble/chat-bubble';
+import { ChatBubble } from '@/components/atoms/chat-bubble/chat-bubble';
 import { cn } from '@/lib/utils';
 
 function useCurrentAppId(): string | undefined {
@@ -174,9 +174,6 @@ export function ChatSidebar() {
                     <ChatBubble key={msg.id} message={msg} />
                 ))}
 
-                {isStreaming && messages[messages.length - 1]?.role !== 'assistant' && (
-                    <TypingIndicator />
-                )}
             </div>
 
             {/* Input */}
@@ -195,7 +192,6 @@ export function ChatSidebar() {
                         }}
                         onKeyDown={handleKeyDown}
                         placeholder="Type your message..."
-                        disabled={isStreaming}
                         rows={1}
                         className="flex-1 resize-none bg-transparent text-sm leading-snug text-foreground outline-none placeholder:text-muted-foreground"
                     />


### PR DESCRIPTION
## Summary
- Fix broken typing indicator (tiny empty dot instead of animated ellipsis) caused by the placeholder assistant message added in #118
- ChatBubble now renders bouncing dots when `_streaming` is true and content is empty
- Remove standalone TypingIndicator guards from chat-panel and chat-sidebar (placeholder bubble handles it)
- Keep chat input enabled during streaming so focus is not lost after pressing Enter

## Test plan
- [x] TypeScript type check passes
- [x] 30 UI tests pass
- [x] Manual: send a message, verify animated bouncing dots appear while waiting for response
- [x] Manual: verify dots are replaced by actual response content when done message arrives

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>