### PR TITLE
chore(deploy): update default image registry to rh-ai-quickstart org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CONTAINER_CLI ?= $(shell command -v podman >/dev/null 2>&1 && echo "podman" || e
 
 # Override with: make push-images REGISTRY=my-registry.example.com REGISTRY_NS=my-org
 REGISTRY    ?= quay.io
-REGISTRY_NS ?= jary
+REGISTRY_NS ?= rh-ai-quickstart
 
 # -- Deployment configuration (OpenShift targets only) -----------------------
 

--- a/deploy/helm/mortgage-ai/values.yaml
+++ b/deploy/helm/mortgage-ai/values.yaml
@@ -9,7 +9,7 @@
 #                       --set secrets.S3_ENDPOINT=https://...
 global:
   imageRegistry: quay.io
-  imageRepository: mortgage-ai
+  imageRepository: rh-ai-quickstart
   imageTag: latest
   imagePullPolicy: Always
   storageClass: ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,7 @@
 #   ENV_FILE        -- env file to source (default: .env)
 #   IMAGE_TAG       -- image tag (default: latest)
 #   REGISTRY        -- registry host (default: quay.io)
-#   REGISTRY_NS     -- registry namespace/org (default: mortgage-ai)
+#   REGISTRY_NS     -- registry namespace/org (default: rh-ai-quickstart)
 #   HELM_TIMEOUT    -- helm timeout (default: 15m)
 #   HELM_EXTRA_ARGS -- additional helm args (default: empty)
 set -euo pipefail
@@ -21,7 +21,7 @@ NAMESPACE="${NAMESPACE:-$PROJECT_NAME}"
 ENV_FILE="${ENV_FILE:-.env}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 REGISTRY="${REGISTRY:-quay.io}"
-REGISTRY_NS="${REGISTRY_NS:-$PROJECT_NAME}"
+REGISTRY_NS="${REGISTRY_NS:-rh-ai-quickstart}"
 HELM_TIMEOUT="${HELM_TIMEOUT:-15m}"
 HELM_EXTRA_ARGS="${HELM_EXTRA_ARGS:-}"
 

--- a/scripts/push-images.sh
+++ b/scripts/push-images.sh
@@ -7,13 +7,13 @@
 #   CONTAINER_CLI  -- podman or docker (default: podman)
 #   IMAGE_TAG      -- image tag (default: latest)
 #   REGISTRY       -- registry host (default: quay.io)
-#   REGISTRY_NS    -- registry namespace/org (default: mortgage-ai)
+#   REGISTRY_NS    -- registry namespace/org (default: rh-ai-quickstart)
 set -euo pipefail
 
 CONTAINER_CLI="${CONTAINER_CLI:-podman}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 REGISTRY="${REGISTRY:-quay.io}"
-REGISTRY_NS="${REGISTRY_NS:-mortgage-ai}"
+REGISTRY_NS="${REGISTRY_NS:-rh-ai-quickstart}"
 
 # Build missing images
 need_build=false


### PR DESCRIPTION
## Summary
- Update default `REGISTRY_NS` from `jary`/`mortgage-ai` to `rh-ai-quickstart` across all deployment config
- Aligned Makefile, Helm values, `push-images.sh`, and `deploy.sh` defaults

## Files changed
- `Makefile` -- `REGISTRY_NS ?= rh-ai-quickstart`
- `deploy/helm/mortgage-ai/values.yaml` -- `imageRepository: rh-ai-quickstart`
- `scripts/push-images.sh` -- fallback default updated
- `scripts/deploy.sh` -- fallback default and comment updated

## Test plan
- [x] `make push-images` successfully pushes to `quay.io/rh-ai-quickstart/`
- [x] Images deployed and running on OCP cluster

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>