### PR TITLE
chore(deploy): values.local.yaml support, seed job OOM fix, MLflow env vars

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -177,7 +177,9 @@
       "Bash(curl * | sh *)",
       "Bash(wget * | sh *)",
       "Read(./.env)",
-      "Read(./.env.*)"
+      "Read(./.env.*)",
+      "Read(./deploy/helm/mortgage-ai/values.local.yaml)",
+      "Read(deploy/helm/mortgage-ai/values.local.yaml)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ agent-memory/
 .env.test.local
 .env.production.local
 
+# Helm local overrides
+values.local.yaml
+
 
 # Logs
 npm-debug.log*

--- a/deploy/helm/mortgage-ai/templates/seed-job.yaml
+++ b/deploy/helm/mortgage-ai/templates/seed-job.yaml
@@ -86,9 +86,9 @@ spec:
                   key: S3_REGION
           resources:
             requests:
-              memory: "256Mi"
+              memory: "1Gi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
+              memory: "2Gi"
               cpu: "500m"
 {{- end }}

--- a/deploy/helm/mortgage-ai/values.local.yaml.example
+++ b/deploy/helm/mortgage-ai/values.local.yaml.example
@@ -1,0 +1,26 @@
+# This project was developed with assistance from AI tools.
+#
+# Local Helm values override -- copy to values.local.yaml and fill in.
+# This file is gitignored and automatically picked up by scripts/deploy.sh.
+#
+# Usage:
+#   cp values.local.yaml.example values.local.yaml
+#   # Edit values.local.yaml with your cluster-specific settings
+#   make deploy
+#
+
+secrets:
+  LLM_BASE_URL: ""
+  LLM_API_KEY: ""
+  LLM_MODEL_FAST: ""
+  LLM_MODEL_CAPABLE: ""
+  COMPANY_NAME: ""
+  # MLFLOW_TRACKING_URI: ""
+  # MLFLOW_EXPERIMENT_NAME: ""
+
+seed:
+  enabled: true
+
+routes:
+  # Set to: <project>-<namespace>.apps.<cluster-domain>
+  sharedHost: ""

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -96,9 +96,11 @@ add_if_set secrets.EMBEDDING_API_KEY EMBEDDING_API_KEY
 add_if_set secrets.SAFETY_MODEL SAFETY_MODEL
 add_if_set secrets.SAFETY_ENDPOINT SAFETY_ENDPOINT
 add_if_set secrets.SAFETY_API_KEY SAFETY_API_KEY
-add_if_set secrets.LANGFUSE_PUBLIC_KEY LANGFUSE_PUBLIC_KEY
-add_if_set secrets.LANGFUSE_SECRET_KEY LANGFUSE_SECRET_KEY
-add_if_set secrets.LANGFUSE_HOST LANGFUSE_HOST
+add_if_set secrets.MLFLOW_TRACKING_URI MLFLOW_TRACKING_URI
+add_if_set secrets.MLFLOW_EXPERIMENT_NAME MLFLOW_EXPERIMENT_NAME
+add_if_set secrets.MLFLOW_WORKSPACE MLFLOW_WORKSPACE
+add_if_set secrets.MLFLOW_TRACKING_TOKEN MLFLOW_TRACKING_TOKEN
+add_if_set secrets.MLFLOW_TRACKING_INSECURE_TLS MLFLOW_TRACKING_INSECURE_TLS
 add_if_set secrets.SQLADMIN_USER SQLADMIN_USER
 add_if_set secrets.SQLADMIN_PASSWORD SQLADMIN_PASSWORD
 add_if_set secrets.SQLADMIN_SECRET_KEY SQLADMIN_SECRET_KEY
@@ -110,13 +112,22 @@ add_if_set secrets.MINIO_ROOT_PASSWORD MINIO_ROOT_PASSWORD
 # Feature toggles (these have safe defaults so always pass)
 SET_ARGS+=(--set "keycloak.enabled=${KEYCLOAK_ENABLED:-true}")
 SET_ARGS+=(--set "llamastack.enabled=${LLAMASTACK_ENABLED:-false}")
-SET_ARGS+=(--set "langfuse.enabled=${LANGFUSE_ENABLED:-false}")
+SET_ARGS+=(--set "seed.enabled=${SEED_ENABLED:-true}")
+
+# Load local values override if present (gitignored, cluster-specific settings)
+VALUES_LOCAL="./deploy/helm/$PROJECT_NAME/values.local.yaml"
+VALUES_FILE_ARGS=()
+if [ -f "$VALUES_LOCAL" ]; then
+    echo "Loading local values from: $VALUES_LOCAL"
+    VALUES_FILE_ARGS+=(-f "$VALUES_LOCAL")
+fi
 
 helm upgrade --install "$PROJECT_NAME" "./deploy/helm/$PROJECT_NAME" \
     --namespace "$NAMESPACE" \
     --timeout "$HELM_TIMEOUT" \
     --wait \
     --wait-for-jobs \
+    "${VALUES_FILE_ARGS[@]}" \
     "${SET_ARGS[@]}" \
     "$@" \
     $HELM_EXTRA_ARGS \


### PR DESCRIPTION
## Summary

- Bump seed job memory to 1Gi request / 2Gi limit (was 256Mi/512Mi) -- it loads the same embedding model as the API pod and was getting OOMKilled
- Add `values.local.yaml` support: gitignored file auto-loaded by `deploy.sh` so cluster-specific settings (LLM keys, model names, company name, routes) persist without long `--set` chains
- Replace stale `LANGFUSE_*` env var passthrough in `deploy.sh` with `MLFLOW_*` vars
- Enable seed job by default (`SEED_ENABLED=true`) in deploy.sh
- Add `values.local.yaml.example` template
- Protect `values.local.yaml` in Claude settings deny rules (same as `.env`)

## Test plan

- [x] `values.local.yaml.example` documents all common override keys
- [x] `deploy.sh` auto-detects and loads `values.local.yaml` when present
- [x] Seed job memory limits match API pod (1Gi/2Gi)
- [x] No test changes -- deploy/infra only

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>