### PR TITLE
chore(ui): consolidate legal disclaimer across all views

### DIFF
--- a/packages/ui/src/components/footer/footer.tsx
+++ b/packages/ui/src/components/footer/footer.tsx
@@ -31,7 +31,10 @@ export function Footer() {
                         &nbsp;&nbsp;Equal Housing Lender.
                     </p>
                     <p className="italic">
-                        {COMPANY_NAME} is a fictional company created for demonstration purposes.
+                        This organization, its activities and its employees are fictional and are
+                        not intended to represent or depict any current or former business
+                        organization or any individuals. Any resemblance to any individual or
+                        organization is purely coincidental.
                     </p>
                 </div>
             </div>

--- a/packages/ui/src/components/footer/footer.tsx
+++ b/packages/ui/src/components/footer/footer.tsx
@@ -4,8 +4,6 @@ import { Logo } from '../logo/logo';
 import { COMPANY_NAME } from '@/lib/company';
 
 export function Footer() {
-    const currentYear = new Date().getFullYear();
-
     return (
         <footer className="w-full bg-[#1e3a5f] text-white dark:bg-black">
             <div className="mx-auto max-w-[1200px] px-4 py-12 sm:px-6 lg:px-8">
@@ -25,11 +23,7 @@ export function Footer() {
                 </div>
 
                 {/* Bottom bar */}
-                <div className="mt-10 flex flex-col gap-2 border-t border-white/10 pt-8 text-xs text-white/50 sm:flex-row sm:items-center sm:justify-between">
-                    <p>
-                        &copy; {currentYear} {COMPANY_NAME}. All rights reserved.
-                        &nbsp;&nbsp;Equal Housing Lender.
-                    </p>
+                <div className="mt-10 border-t border-white/10 pt-8 text-xs text-white/50">
                     <p className="italic">
                         This organization, its activities and its employees are fictional and are
                         not intended to represent or depict any current or former business

--- a/packages/ui/src/components/molecules/affordability-form/affordability-form.tsx
+++ b/packages/ui/src/components/molecules/affordability-form/affordability-form.tsx
@@ -254,7 +254,7 @@ export function AffordabilityForm() {
 
                             <p className="text-xs leading-5 text-muted-foreground">
                                 Estimates are for illustrative purposes only and do not constitute
-                                a loan commitment. Actual rates and terms may vary. This organization, its activities and its employees are fictional and are not intended to represent or depict any current or former business organization or any individuals. Any resemblance to any individual or organization is purely coincidental.
+                                a loan commitment. Actual rates and terms may vary.
                             </p>
                         </div>
                     </div>

--- a/packages/ui/src/components/molecules/affordability-form/affordability-form.tsx
+++ b/packages/ui/src/components/molecules/affordability-form/affordability-form.tsx
@@ -7,7 +7,6 @@ import { useChatContext } from '@/contexts/chat-context';
 import { Label } from '@/components/atoms/label/label';
 import { formatCurrency } from '@/lib/format';
 import type { AffordabilityRequest } from '@/schemas/affordability';
-import { COMPANY_NAME } from '@/lib/company';
 
 interface FormState {
     gross_annual_income: string;
@@ -255,7 +254,7 @@ export function AffordabilityForm() {
 
                             <p className="text-xs leading-5 text-muted-foreground">
                                 Estimates are for illustrative purposes only and do not constitute
-                                a loan commitment. Actual rates and terms may vary. {COMPANY_NAME} is a fictional company created for demonstration purposes.
+                                a loan commitment. Actual rates and terms may vary. This organization, its activities and its employees are fictional and are not intended to represent or depict any current or former business organization or any individuals. Any resemblance to any individual or organization is purely coincidental.
                             </p>
                         </div>
                     </div>

--- a/packages/ui/src/routes/__root.tsx
+++ b/packages/ui/src/routes/__root.tsx
@@ -25,9 +25,9 @@ function RootLayoutInner() {
     const showPublicChat = !isAuthenticated;
 
     return (
-        <div className="flex min-h-screen flex-col">
+        <div className={`flex flex-col ${isAuthenticated ? 'h-screen overflow-hidden' : 'min-h-screen'}`}>
             <Header />
-            <main className="flex-1">
+            <main className={`flex-1 ${isAuthenticated ? 'overflow-hidden' : ''}`}>
                 <Outlet />
             </main>
             {showPublicChat && <Footer />}

--- a/packages/ui/src/routes/_authenticated.tsx
+++ b/packages/ui/src/routes/_authenticated.tsx
@@ -60,12 +60,12 @@ function AuthenticatedLayout() {
     return (
         <div className="flex flex-1 flex-col overflow-hidden">
             <div className="flex flex-1 overflow-hidden">
-                <main className="flex-1 overflow-y-auto lg:pr-[340px]">
+                <main className="flex-1 overflow-y-auto pb-10 lg:pr-[340px]">
                     <Outlet />
                 </main>
                 <ChatSidebar />
             </div>
-            <div className="shrink-0 border-t border-border bg-slate-50 px-4 py-1.5 text-center text-[10px] leading-tight text-muted-foreground dark:bg-slate-900 lg:pr-[340px]">
+            <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-border bg-slate-50 px-4 py-1.5 text-center text-[10px] leading-tight text-muted-foreground dark:bg-slate-900 lg:right-[320px]">
                 This organization, its activities and its employees are fictional and are not intended to represent
                 or depict any current or former business organization or any individuals. Any resemblance to any
                 individual or organization is purely coincidental.

--- a/packages/ui/src/routes/_authenticated.tsx
+++ b/packages/ui/src/routes/_authenticated.tsx
@@ -58,11 +58,18 @@ function AuthenticatedLayout() {
     }
 
     return (
-        <div className="flex flex-1 overflow-hidden">
-            <main className="flex-1 overflow-y-auto lg:pr-[340px]">
-                <Outlet />
-            </main>
-            <ChatSidebar />
+        <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="flex flex-1 overflow-hidden">
+                <main className="flex-1 overflow-y-auto lg:pr-[340px]">
+                    <Outlet />
+                </main>
+                <ChatSidebar />
+            </div>
+            <div className="shrink-0 border-t border-border bg-slate-50 px-4 py-1.5 text-center text-[10px] leading-tight text-muted-foreground dark:bg-slate-900 lg:pr-[340px]">
+                This organization, its activities and its employees are fictional and are not intended to represent
+                or depict any current or former business organization or any individuals. Any resemblance to any
+                individual or organization is purely coincidental.
+            </div>
         </div>
     );
 }

--- a/packages/ui/src/routes/_authenticated/ceo/audit.tsx
+++ b/packages/ui/src/routes/_authenticated/ceo/audit.tsx
@@ -13,7 +13,6 @@ import { useAuditEventsFiltered } from '@/hooks/use-audit';
 import type { AuditEventItem } from '@/schemas/audit';
 import { cn } from '@/lib/utils';
 import { staffName } from '@/lib/staff-names';
-import { COMPANY_NAME } from '@/lib/company';
 
 export const Route = createFileRoute('/_authenticated/ceo/audit')({
     component: AuditTrailPage,
@@ -348,8 +347,10 @@ function AuditTrailPage() {
 
             {/* Footer disclaimer */}
             <p className="mt-8 text-center text-xs text-muted-foreground">
-                {COMPANY_NAME} is a fictional company. All data is simulated for demonstration purposes.
-                Regulatory references (HMDA, ECOA, TRID, FCRA) are simplified representations, not legal guidance.
+                This organization, its activities and its employees are fictional and are not intended to represent
+                or depict any current or former business organization or any individuals. Any resemblance to any
+                individual or organization is purely coincidental. Regulatory references (HMDA, ECOA, TRID, FCRA)
+                are simplified representations, not legal guidance.
             </p>
         </div>
     );

--- a/packages/ui/src/routes/_authenticated/ceo/audit.tsx
+++ b/packages/ui/src/routes/_authenticated/ceo/audit.tsx
@@ -345,13 +345,6 @@ function AuditTrailPage() {
                 )}
             </div>
 
-            {/* Footer disclaimer */}
-            <p className="mt-8 text-center text-xs text-muted-foreground">
-                This organization, its activities and its employees are fictional and are not intended to represent
-                or depict any current or former business organization or any individuals. Any resemblance to any
-                individual or organization is purely coincidental. Regulatory references (HMDA, ECOA, TRID, FCRA)
-                are simplified representations, not legal guidance.
-            </p>
         </div>
     );
 }

--- a/packages/ui/src/routes/_authenticated/ceo/index.tsx
+++ b/packages/ui/src/routes/_authenticated/ceo/index.tsx
@@ -518,8 +518,10 @@ function CeoDashboard() {
 
             {/* Footer disclaimer */}
             <p className="mt-8 text-center text-xs text-muted-foreground">
-                {COMPANY_NAME} is a fictional company. All data is simulated for demonstration purposes.
-                Regulatory references (HMDA, ECOA, TRID, FCRA) are simplified representations, not legal guidance.
+                This organization, its activities and its employees are fictional and are not intended to represent
+                or depict any current or former business organization or any individuals. Any resemblance to any
+                individual or organization is purely coincidental. Regulatory references (HMDA, ECOA, TRID, FCRA)
+                are simplified representations, not legal guidance.
             </p>
         </div>
     );

--- a/packages/ui/src/routes/_authenticated/ceo/index.tsx
+++ b/packages/ui/src/routes/_authenticated/ceo/index.tsx
@@ -516,13 +516,6 @@ function CeoDashboard() {
             {/* Audit events - full width */}
             {auditEvents.isLoading ? <AuditEventsSkeleton /> : auditEvents.data ? <AuditEventsCard data={auditEvents.data} /> : null}
 
-            {/* Footer disclaimer */}
-            <p className="mt-8 text-center text-xs text-muted-foreground">
-                This organization, its activities and its employees are fictional and are not intended to represent
-                or depict any current or former business organization or any individuals. Any resemblance to any
-                individual or organization is purely coincidental. Regulatory references (HMDA, ECOA, TRID, FCRA)
-                are simplified representations, not legal guidance.
-            </p>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Update all disclaimer text to legal-approved language from Erwan Granger
- Remove copyright and Equal Housing Lender line from footer (contradicts fictional company disclaimer)
- Remove redundant disclaimer from affordability calculator (footer already covers it)
- Dock disclaimer to viewport bottom using fixed positioning in authenticated layout, scoped to main content panel width (does not overlap chat sidebar)
- Remove duplicate inline disclaimers from CEO dashboard and audit pages
- Constrain authenticated layout to viewport height so content scrolls internally

## Test plan
- [x] Public landing page: footer shows updated disclaimer, no copyright line
- [x] Affordability calculator: shows only loan estimate caveat, no org disclaimer
- [x] Borrower view: disclaimer docked to viewport bottom, visible while scrolling
- [x] Loan Officer view: disclaimer docked, chat input not obscured
- [x] Underwriter view: disclaimer docked, aligned to chat sidebar edge
- [x] CEO dashboard: single disclaimer (no duplicate), docked to bottom
- [x] CEO audit trail: single disclaimer (no duplicate), docked to bottom
- [x] Mobile: disclaimer spans full width, chat panel unaffected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>