### PR TITLE
fix(deploy): add missing mcpRiskServer values and MCP secret keys

### DIFF
--- a/deploy/helm/mortgage-ai/values.local.yaml.example
+++ b/deploy/helm/mortgage-ai/values.local.yaml.example
@@ -39,3 +39,6 @@ keycloak:
 mlflow:
   rbac:
     enabled: true
+
+mcpRiskServer:
+  enabled: true

--- a/deploy/helm/mortgage-ai/values.yaml
+++ b/deploy/helm/mortgage-ai/values.yaml
@@ -63,6 +63,10 @@ secrets:
   EMBEDDING_BASE_URL: ""
   EMBEDDING_API_KEY: ""
 
+  # MCP risk server
+  MCP_RISK_SERVER_URL: "http://mcp-risk-server:8081/mcp"
+  PREDICTIVE_MODEL_MCP_URL: ""
+
   # Safety / Shields (optional)
   SAFETY_MODEL: ""
   SAFETY_ENDPOINT: ""
@@ -219,6 +223,29 @@ mlflow:
     pipelineRunner:
       enabled: false  # Enable when DSPA is deployed in this namespace
       serviceAccountName: pipeline-runner-dspa  # SA created by DSPA operator
+
+# MCP Risk Server (optional)
+mcpRiskServer:
+  enabled: true
+  name: mcp-risk-server
+  image:
+    repository: mortgage-ai-api
+    tag: latest
+  replicas: 1
+  service:
+    type: ClusterIP
+    port: 8081
+  healthCheck:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 # LlamaStack model serving
 llamastack:


### PR DESCRIPTION
## Summary

- Add `mcpRiskServer` section to `values.yaml` (fixes nil pointer error in `mcp-risk-server.yaml` template)
- Add `MCP_RISK_SERVER_URL` and `PREDICTIVE_MODEL_MCP_URL` to the `secrets` block (fixes undefined keys in `secret.yaml` template)

## Rationale

The Helm chart fails to render on `helm install/upgrade` because:

1. `templates/mcp-risk-server.yaml` accesses `.Values.mcpRiskServer.enabled` but the `mcpRiskServer` object didn't exist in `values.yaml`, causing a Go template nil pointer dereference
2. `templates/secret.yaml` references `MCP_RISK_SERVER_URL` and `PREDICTIVE_MODEL_MCP_URL` but they were missing from the `secrets` block, rendering empty/broken secret entries

Both issues are resolved by adding the missing default values. The MCP risk server is enabled by default and reuses the `mortgage-ai-api` image with `python -m src.mcp_server` as the entrypoint.

## Test plan

- [x] `helm template` renders cleanly with no nil pointer errors
- [x] `helm upgrade --install` deploys all pods successfully
- [x] `mcp-risk-server` pod starts and passes health checks
- [x] `mortgage-ai-api` pod connects to MCP risk server on startup (no longer crashes)
- [x] Verified on cluster `cluster-m9bbv`

Assisted-by: Claude Code