### PR TITLE
feat(deploy): add qwen3-8b CPU model serving manifests and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,52 @@ make status      # Show deployment status
 make undeploy    # Remove deployment
 ```
 
+#### OpenShift AI CPU model serving (Qwen3-8B example)
+
+For OpenShift deployments that use CPU model serving, this repository includes KServe/vLLM manifests in `deploy/qwen3-8b/cpu/`.
+
+This CPU-serving configuration supports x86_64 server CPUs, including Intel Xeon platforms.
+
+Treat this as a separate model-serving deployment from the application Helm chart if you dont have an active OpenAI-compatible API and are interested to try CPU serving
+
+**Hardware Requirements**
+
+- Intel Xeon processor-based worker nodes
+- 32 CPU cores minimum per node
+- 64GB RAM minimum per node
+
+1. Deploy the model serving resources:
+
+```bash
+oc apply -k deploy/qwen3-8b/cpu
+```
+
+2. Wait for the InferenceService to become ready:
+
+```bash
+oc get inferenceservice qwen3-8b-cpu -w
+```
+
+3. Capture the endpoint URL:
+
+```bash
+ISVC_URL=$(oc get inferenceservice qwen3-8b-cpu -o jsonpath='{.status.url}')
+echo "$ISVC_URL"
+```
+
+4. Deploy the application chart and point it to that OpenAI-compatible endpoint:
+
+```bash
+helm upgrade --install mortgage-ai ./deploy/helm/mortgage-ai \
+  --set secrets.LLM_BASE_URL="${ISVC_URL}/v1" \
+  --set secrets.LLM_API_KEY="not-needed" \
+  --set secrets.LLM_MODEL="Qwen/Qwen3-8B"
+```
+
+You do not need to package the Qwen CPU manifests into this chart unless you specifically want single-command infrastructure + app provisioning.
+
+`LLM_BASE_URL` should point to the OpenAI-compatible API root and include `/v1`.
+
 See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed OpenShift deployment configuration, resource requirements, and troubleshooting.
 
 ### Delete
@@ -253,6 +299,8 @@ LLM_BASE_URL=http://localhost:1234/v1
 LLM_API_KEY=not-needed
 LLM_MODEL=qwen3-30b-a3b
 ```
+
+`LLM_BASE_URL` must point to the OpenAI-compatible API root and should include `/v1`.
 
 See `.env.example` for all available settings including database connection, authentication, safety shields, and MLflow observability.
 

--- a/deploy/helm/mortgage-ai/templates/api-deployment.yaml
+++ b/deploy/helm/mortgage-ai/templates/api-deployment.yaml
@@ -300,18 +300,20 @@ spec:
             httpGet:
               path: {{ .Values.api.healthCheck.path }}
               port: http
-            failureThreshold: 30
+            failureThreshold: 60
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: {{ .Values.api.healthCheck.path }}
               port: http
             periodSeconds: {{ .Values.api.healthCheck.periodSeconds }}
+            failureThreshold: {{ .Values.api.healthCheck.failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path: {{ .Values.api.healthCheck.path }}
               port: http
             periodSeconds: {{ .Values.api.healthCheck.periodSeconds }}
+            failureThreshold: {{ .Values.api.healthCheck.failureThreshold | default 3 }}
           {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}

--- a/deploy/helm/mortgage-ai/values.yaml
+++ b/deploy/helm/mortgage-ai/values.yaml
@@ -68,6 +68,10 @@ secrets:
   SAFETY_ENDPOINT: ""
   SAFETY_API_KEY: ""
 
+  # MCP servers
+  MCP_RISK_SERVER_URL: "http://mcp-risk-server:8081/mcp"
+  PREDICTIVE_MODEL_MCP_URL: "http://mcp-risk-server:8081/mcp"
+
   # Observability (MLflow) -- leave blank to disable MLflow tracing
   MLFLOW_TRACKING_URI: ""
   # Auth mode: set to "kubernetes" on RHOAI 3.4+ for automatic SA token auth.
@@ -219,6 +223,29 @@ mlflow:
     pipelineRunner:
       enabled: false  # Enable when DSPA is deployed in this namespace
       serviceAccountName: pipeline-runner-dspa  # SA created by DSPA operator
+
+# MCP Risk Server (optional)
+mcpRiskServer:
+  enabled: true
+  name: mcp-risk-server
+  replicas: 1
+  image:
+    repository: mortgage-ai-api
+    tag: latest
+  service:
+    type: ClusterIP
+    port: 8081
+  healthCheck:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 15
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "384Mi"
+      cpu: "500m"
 
 # LlamaStack model serving
 llamastack:

--- a/deploy/qwen3-8b/cpu/inferenceservice.yaml
+++ b/deploy/qwen3-8b/cpu/inferenceservice.yaml
@@ -1,0 +1,43 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  annotations:
+    openshift.io/display-name: qwen3-8b-cpu
+    serving.kserve.io/deploymentMode: RawDeployment
+  name: qwen3-8b-cpu
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  predictor:
+    maxReplicas: 1
+    minReplicas: 1
+    model:
+      modelFormat:
+        name: vLLM
+      name: ''
+      env:
+        - name: VLLM_CACHE_DIR
+          value: "/tmp/vllm_cache"
+        - name: XDG_CACHE_HOME
+          value: "/tmp/.cache"
+        - name: VLLM_CPU_KVCACHE_SPACE
+          value: "4"
+        - name: VLLM_RPC_TIMEOUT
+          value: "100000"
+        - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+          value: "1"
+        - name: VLLM_ENGINE_ITERATION_TIMEOUT_S
+          value: "120"
+        - name: VLLM_CPU_SGL_KERNEL
+          value: "1"
+        - name: HF_HUB_DISABLE_XET
+          value: "1"
+      resources:
+        limits:
+          cpu: '16'
+          memory: 32Gi
+        requests:
+          cpu: '16'
+          memory: 32Gi
+      runtime: qwen3-8b-cpu
+      storageUri: 'hf://Qwen/Qwen3-8B'

--- a/deploy/qwen3-8b/cpu/kustomization.yaml
+++ b/deploy/qwen3-8b/cpu/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - oci-data-connection.yaml
+  - servingruntime.yaml
+  - inferenceservice.yaml

--- a/deploy/qwen3-8b/cpu/oci-data-connection.yaml
+++ b/deploy/qwen3-8b/cpu/oci-data-connection.yaml
@@ -1,0 +1,13 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: qwen3-8b-instruct
+  labels:
+    opendatahub.io/dashboard: 'true'
+  annotations:
+    opendatahub.io/connection-type-ref: uri-v1
+    openshift.io/description: ''
+    openshift.io/display-name: qwen3-8b-instruct
+data:
+  URI: b2NpOi8vcXVheS5pby9yZWRoYXQtYWktc2VydmljZXMvbW9kZWxjYXItY2F0YWxvZzpxd2VuLTMtOGItaW5zdHJ1Y3Q=
+type: Opaque

--- a/deploy/qwen3-8b/cpu/servingruntime.yaml
+++ b/deploy/qwen3-8b/cpu/servingruntime.yaml
@@ -1,0 +1,58 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  annotations:
+    opendatahub.io/apiProtocol: REST
+    opendatahub.io/recommended-accelerators: '["cpu"]'
+    opendatahub.io/template-display-name: vLLM CPU ServingRuntime for KServe
+    opendatahub.io/template-name: vllm-xeon-runtime
+    openshift.io/display-name: qwen3-8b-cpu
+  name: qwen3-8b-cpu
+  labels:
+    opendatahub.io/dashboard: 'true'
+spec:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: '8080'
+  containers:
+    - args:
+        - '--port=8080'
+        - '--model=/mnt/models'
+        - '--served-model-name={{.Name}}'
+        - '--block-size=128'
+        - '--dtype=bfloat16'
+        - '--max-model-len=8192'
+        - '--distributed-executor-backend=mp'
+        - '--max-num-batched-tokens=4096'
+        - '--max-num-seqs=128'
+        - '--tensor-parallel-size=1'
+        - '--pipeline-parallel-size=1'
+        - '--enable-auto-tool-choice'
+        - '--tool-call-parser=hermes'
+      command:
+        - vllm
+        - serve
+      env:
+        - name: OMP_NUM_THREADS
+          value: "16"
+        - name: VLLM_CPU_OMP_THREADS_BIND
+          value: "0-15"
+        - name: VLLM_LOGGING_LEVEL
+          value: "INFO"
+      image: 'quay.io/vllm/automation-vllm:cpu-24724916834'
+      name: kserve-container
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      volumeMounts:
+        - mountPath: /dev/shm
+          name: shm
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: vLLM
+  volumes:
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 16Gi
+      name: shm


### PR DESCRIPTION
Description

- Add KServe/vLLM CPU manifests under deploy/qwen3-8b/cpu/
- Add OpenShift AI CPU deployment instructions to README
- Add mcpRiskServer default values to Helm chart
- Add MCP_RISK_SERVER_URL and PREDICTIVE_MODEL_MCP_URL secret defaults

## Related issues

<!-- Link issues with keywords like Closes/Resolves/Fixes. Example: Closes #123 -->
- Closes #
- Related to #


## How was this tested / what tests were added?

<!-- Describe the testing approach. List new/updated tests and any manual steps. -->
- Automated:

- Manual: Tested the QS on Xeon 6 / GNR


## Screenshots or recordings (if applicable)

<!-- Add before/after visuals, GIFs, or console output when UI/UX changes are involved. -->


## Documentation updates

<!-- Describe any docs updates or additions -->
- [ ] Changes are self documenting
- [ ] Inline docs added- inline docs added
- [ ] Formal docs added
