### PR TITLE
fix(api): use HumanMessage for per-turn system context injection

### DIFF
--- a/packages/api/src/routes/_chat_handler.py
+++ b/packages/api/src/routes/_chat_handler.py
@@ -14,7 +14,7 @@ import uuid
 import jwt as pyjwt
 from db.enums import UserRole
 from fastapi import APIRouter, Depends, Query, WebSocket
-from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 
 from ..agents.registry import get_agent
 from ..core.auth import build_data_scope
@@ -287,7 +287,7 @@ async def run_agent_stream(
             # Inject system context once on the first message of the conversation
             context_msgs: list = []
             if system_context:
-                context_msgs = [SystemMessage(content=system_context)]
+                context_msgs = [HumanMessage(content=system_context)]
                 system_context = ""  # Only inject once
 
             if use_checkpointer:


### PR DESCRIPTION
## Summary
Karl discovered an issue with Borrower chat. After doing a couple disclosure acceptances, he sent another message and received the agent is unavailable message. This was caused by the responses including SystemMessage content, so subsequent messages had SystemMessage intermixed with HumanMessages and Qwen only accepts SystemMessage at the start of the input - Screenshots attached for 

## Changes
- Change per-turn application context injection from SystemMessage to HumanMessage in persistent chat threads
- LiteLLM's Qwen handler enforces system messages at the beginning of the message list; when a borrower reconnects to a checkpointed thread, prior SystemMessage entries end up mid-conversation, causing 400 errors
- The context content is already bracketed with `[System context]` so the LLM treats it as instructions regardless of message type

## Test plan
- [x] Start a borrower chat session, send a message, verify response
- [x] Disconnect and reconnect to the same thread, send another message -- should no longer get "System message must be at the beginning" error
- [x] Verify the agent still receives and acts on the application context (correct app ID in tool calls)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

trace error:
<img width="1700" height="482" alt="trace-error" src="https://github.com/user-attachments/assets/894af6fb-9961-4cb0-b8f7-841a4d97d35c" />

before fix:
<img width="417" height="1333" alt="before-fix" src="https://github.com/user-attachments/assets/eb1a10ff-e487-4e01-8c0d-ab3276e2cf19" />

after fix:
<img width="429" height="1530" alt="after-fix" src="https://github.com/user-attachments/assets/34355cdb-729b-49b4-9736-ada9245c4b96" />
