### PR TITLE
feat(deploy): delegate MLflow config to Kagenti Operator when enabled

### DIFF
--- a/deploy/helm/mortgage-ai/templates/api-deployment.yaml
+++ b/deploy/helm/mortgage-ai/templates/api-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         kagenti.io/outbound-ports-exclude: {{ .Values.kagenti.outboundPortsExclude | quote }}
       {{- end }}
     spec:
-      {{- if .Values.mlflow.rbac.enabled }}
+      {{- if and .Values.mlflow.rbac.enabled (not .Values.kagenti.enabled) }}
       serviceAccountName: {{ include "mortgage-ai.fullname" . }}-mlflow-client
       {{- else }}
       serviceAccountName: {{ include "mortgage-ai.serviceAccountName" . }}
@@ -262,6 +262,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mortgage-ai.fullname" . }}-secret
                   key: NEMO_GUARDRAILS_ENDPOINT
+            {{- if not .Values.kagenti.enabled }}
             - name: MLFLOW_TRACKING_URI
               valueFrom:
                 secretKeyRef:
@@ -287,6 +288,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mortgage-ai.fullname" . }}-secret
                   key: MLFLOW_TRACKING_INSECURE_TLS
+            {{- end }}
             - name: SQLADMIN_USER
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/mortgage-ai/templates/mlflow-rbac.yaml
+++ b/deploy/helm/mortgage-ai/templates/mlflow-rbac.yaml
@@ -1,5 +1,5 @@
 # This project was developed with assistance from AI tools.
-{{- if .Values.mlflow.rbac.enabled }}
+{{- if and .Values.mlflow.rbac.enabled (not .Values.kagenti.enabled) }}
 ---
 # MLflow integration ClusterRole for RHOAI 3.4+ MLflow server access.
 # This ClusterRole grants permissions to interact with MLflow CRDs

--- a/deploy/helm/mortgage-ai/templates/secret.yaml
+++ b/deploy/helm/mortgage-ai/templates/secret.yaml
@@ -63,11 +63,15 @@ data:
   {{- end }}
 
   # API -- MLflow observability
+  # When kagenti.enabled=true, the Kagenti Operator MLflow controller auto-injects
+  # these env vars by detecting the kagenti.io/type=agent label on the Deployment.
+  {{- if not .Values.kagenti.enabled }}
   MLFLOW_TRACKING_URI: {{ .Values.secrets.MLFLOW_TRACKING_URI | toString | b64enc | quote }}
   MLFLOW_EXPERIMENT_NAME: {{ .Values.secrets.MLFLOW_EXPERIMENT_NAME | toString | b64enc | quote }}
   MLFLOW_WORKSPACE: {{ .Values.secrets.MLFLOW_WORKSPACE | toString | b64enc | quote }}
   MLFLOW_TRACKING_TOKEN: {{ .Values.secrets.MLFLOW_TRACKING_TOKEN | toString | b64enc | quote }}
   MLFLOW_TRACKING_INSECURE_TLS: {{ .Values.secrets.MLFLOW_TRACKING_INSECURE_TLS | toString | b64enc | quote }}
+  {{- end }}
 
   # API -- admin panel
   SQLADMIN_USER: {{ .Values.secrets.SQLADMIN_USER | toString | b64enc | quote }}

--- a/deploy/helm/mortgage-ai/values.yaml
+++ b/deploy/helm/mortgage-ai/values.yaml
@@ -214,10 +214,18 @@ minio:
       cpu: "500m"
 
 # MLflow observability (RHOAI 3.4+)
+# When kagenti.enabled=true, the Kagenti Operator MLflow controller handles MLflow
+# automatically: it auto-discovers MLflow from the mlflows.mlflow.opendatahub.io CR,
+# creates the experiment, injects MLFLOW_* env vars, and sets up RBAC -- so the
+# manual RBAC and env var configuration below is skipped.
+# Prerequisites for Kagenti-managed MLflow:
+#   1. Enable MLflow in the DataScienceCluster (RHOAI 3.4+)
+#   2. Install Kagenti (./scripts/ocp/setup-kagenti.sh)
+#   3. Agents use mlflow[kubernetes]>=3.11 SDK
 mlflow:
-  # RBAC resources for MLflow server access
+  # RBAC resources for MLflow server access (skipped when kagenti.enabled=true)
   rbac:
-    enabled: true  # Enable when deploying with RHOAI MLflow
+    enabled: true  # Enable when deploying with RHOAI MLflow without Kagenti
     # Creates: ClusterRole, ServiceAccount, ClusterRoleBinding
     # The ServiceAccount can be used to generate tokens for MLflow auth
     pipelineRunner:


### PR DESCRIPTION
## Summary
- When `kagenti.enabled=true`, skip manual MLflow RBAC (ClusterRole, ServiceAccount, ClusterRoleBinding), secret entries, and env var injection in the API deployment
- The Kagenti Operator MLflow controller auto-discovers MLflow from the `mlflows.mlflow.opendatahub.io` CR, creates experiments, injects `MLFLOW_*` env vars, and sets up RBAC via the `kagenti.io/type: agent` label
- Manual MLflow configuration is preserved as fallback when Kagenti is not enabled
- Prerequisites documented in `values.yaml`: RHOAI 3.4+ MLflow, Kagenti installed, `mlflow[kubernetes]>=3.11` SDK

## Files changed
- `templates/mlflow-rbac.yaml` -- guard with `(not .Values.kagenti.enabled)`
- `templates/api-deployment.yaml` -- skip mlflow-client SA and MLFLOW_* env vars when Kagenti manages them
- `templates/secret.yaml` -- skip MLflow secret entries when Kagenti manages them
- `values.yaml` -- document Kagenti MLflow automation and prerequisites

## Test plan
- [ ] `helm template` with `kagenti.enabled=true` produces no MLflow RBAC or env vars
- [ ] `helm template` with `kagenti.enabled=false` produces all MLflow RBAC and env vars (backwards compatible)
- [ ] Deploy with Kagenti enabled on cluster and verify MLflow env vars are auto-injected by the operator

Generated with [Claude Code](https://claude.com/claude-code)