### PR TITLE
docs: align README with quickstart contrib guidelines

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ Maturity level is **MVP**. See `.claude/rules/maturity-expectations.md` for what
 
 - **Python 3.11+** backend (stakeholder mandate)
 - **LangGraph** for agent orchestration (stakeholder mandate)
-- **LangFuse** self-hosted for observability -- must run as a container, not their cloud service (stakeholder mandate)
+- **MLflow** for observability -- integrated with RHOAI 3.4+ for production; self-hosted container for local dev (stakeholder mandate)
 - **LlamaStack** for model serving abstraction (stakeholder mandate)
 - **FastAPI** + **Pydantic 2.x** (stakeholder mandate)
 - **uv** for Python package management, **Ruff** for linting, **pytest** for testing (stakeholder mandate)
@@ -57,7 +57,7 @@ Maturity level is **MVP**. See `.claude/rules/maturity-expectations.md` for what
 - **Language (Backend):** Python 3.11+
 - **Language (Frontend):** TypeScript 5.x
 - **AI/Agent Framework:** LangGraph
-- **Observability:** LangFuse (self-hosted)
+- **Observability:** MLflow (RHOAI 3.4+ / self-hosted)
 - **LLM Stack:** LlamaStack (model serving abstraction)
 - **Model Hosting:** OpenShift AI (prod); local or OpenAI API-compatible (dev)
 - **Web Framework:** FastAPI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ cd packages/db && pnpm migrate:new -m "description"  # Create migration
 cd packages/db && pnpm migrate                       # Apply migrations
 
 # Containers
-make run                # Full stack (postgres, api, ui, keycloak, langfuse)
+make run                # Full stack (postgres, api, ui, keycloak, mlflow)
 make run-minimal        # Just postgres + api + ui
 make stop               # Stop all
 
@@ -116,7 +116,7 @@ input -> input_shield -> classify (rule-based) -> agent_fast / agent_capable
 - **Embeddings:** Local by default (`nomic-ai/nomic-embed-text-v1.5`); optional remote via `EMBEDDING_PROVIDER=openai_compatible`
 - **Auth:** Keycloak OIDC; bypass with `AUTH_DISABLED=true` for dev
 - **Storage:** MinIO S3-compatible for documents
-- **Observability:** LangFuse for agent tracing (optional)
+- **Observability:** MLflow for agent tracing (optional)
 
 ## Critical Patterns
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This quickstart demonstrates AI patterns for regulated industries including role
 - OpenShift cluster with Red Hat OpenShift AI installed
 - LLM access via either:
   - Model-as-a-Service (MaaS) endpoint (no GPU required on cluster), or
-  - GPU node for on-cluster model serving (NVIDIA A10G or equivalent recommended)
+  - GPU node for on-cluster model serving (sized for your chosen model)
 - Persistent volume claims: 10Gi for PostgreSQL, 10Gi for MinIO object storage
 - See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed cluster sizing and configuration
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ This quickstart demonstrates AI patterns for regulated industries including role
   - Model-as-a-Service (MaaS) endpoint (no GPU required on cluster), or
   - GPU node for on-cluster model serving (sized for your chosen model)
 - Persistent volume claims: 10Gi for PostgreSQL, 10Gi for MinIO object storage
-- See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed cluster sizing and configuration
 
 ### Minimum software requirements
 
@@ -142,8 +141,6 @@ make status      # Show deployment status
 make undeploy    # Remove deployment
 ```
 
-See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed OpenShift deployment configuration, resource requirements, and troubleshooting.
-
 ### Delete
 
 To tear down the local development environment:
@@ -161,7 +158,6 @@ make undeploy   # Remove Helm deployment
 
 ## References
 
-- [Documentation Site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/)
 - [API Documentation](http://localhost:8000/docs) (available when running locally)
 - [Red Hat AI Quickstart Catalog](https://github.com/rh-ai-quickstart)
 - Package READMEs:

--- a/README.md
+++ b/README.md
@@ -60,19 +60,22 @@ Demo video inclusion/timeline TBD.
 - 20GB available disk space for container images and model files
 - Multi-core CPU (4+ cores recommended)
 
-**For OpenShift deployment:**
+**For OpenShift deployment (tested with OpenShift 4.21):**
 
-- OpenShift cluster with OpenShift AI installed
-- Persistent volume claims for PostgreSQL and MinIO storage
-- See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed cluster requirements
+- OpenShift cluster with Red Hat OpenShift AI installed
+- LLM access via either:
+  - Model-as-a-Service (MaaS) endpoint (no GPU required on cluster), or
+  - GPU node for on-cluster model serving (NVIDIA A10G or equivalent recommended)
+- Persistent volume claims: 10Gi for PostgreSQL, 10Gi for MinIO object storage
+- See the [documentation site](https://rh-ai-quickstart.github.io/multi-agent-loan-origination/) for detailed cluster sizing and configuration
 
 ### Minimum software requirements
 
-- Node.js 18+ and pnpm 9+
-- Python 3.11+ and [uv](https://docs.astral.sh/uv/)
-- Podman 4+ and podman-compose
-- PostgreSQL 16 (provided via compose for local development)
-- An OpenAI-compatible LLM endpoint (local inference server, OpenShift AI model serving, vLLM, or any compatible API)
+- Node.js 22+ and pnpm 9+ (tested with Node.js 22 LTS, pnpm 9.15)
+- Python 3.11+ and [uv](https://docs.astral.sh/uv/) (tested with Python 3.13, uv 0.11)
+- Podman 4+ and podman-compose (tested with Podman 4.9)
+- PostgreSQL 16 with pgvector (provided via compose for local development)
+- An OpenAI-compatible LLM endpoint (local inference server, OpenShift AI model serving, or any compatible API)
 
 ## Deploy
 
@@ -118,6 +121,13 @@ To run the full stack including Keycloak:
 ```bash
 make run      # Start all containers
 make stop     # Stop all containers
+```
+
+To build and push container images, use the Docker CLI to avoid podman compatibility issues with certain dependencies:
+
+```bash
+make build-images CONTAINER_CLI=docker
+make push-images CONTAINER_CLI=docker
 ```
 
 Run `make help` for additional container targets including individual service profiles, image builds, and log streaming.
@@ -311,6 +321,3 @@ When the variable is unset or empty, the feature is disabled and the underwriter
 ## Tags
 
 - **Industry**: Financial Services
-- **Product**: OpenShift AI
-- **Use case**: Multi-agent orchestration
-- **Contributor org**: Red Hat

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This quickstart demonstrates AI patterns for regulated industries including role
 
 ### See it in action
 
-[Interactive walkthrough on Red Hat Interact](https://interact.redhat.com/share/UgvwvL982CGksrFdjHT1)
+[Interactive walkthrough](https://interact.redhat.com/share/UgvwvL982CGksrFdjHT1)
 
 ### Architecture diagrams
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This quickstart demonstrates AI patterns for regulated industries including role
 
 ### See it in action
 
-Demo video inclusion/timeline TBD.
+[Interactive walkthrough on Red Hat Interact](https://interact.redhat.com/share/UgvwvL982CGksrFdjHT1)
 
 ### Architecture diagrams
 


### PR DESCRIPTION
## Summary

- Trim tags section to `Industry: Financial Services` only (per [quickstart contrib spec](https://github.com/rh-ai-quickstart/ai-quickstart-contrib/blob/main/CONTRIBUTING.md#readme-file-specifications), additional tag types are not yet supported)
- Add tested versions to software requirements (Node 22 LTS, Python 3.13, Podman 4.9, uv 0.11, pnpm 9.15)
- Expand OpenShift hardware requirements with OCP 4.21 version, MaaS vs GPU model serving options, and PVC sizing
- Add `CONTAINER_CLI=docker` note for image builds to work around podman compatibility issues
- Fix stale LangFuse references to MLflow in CLAUDE.md and .claude/CLAUDE.md

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] Confirm all section ordering matches quickstart spec (15 sections)

Co-Authored-By: Claude Opus 