### PR TITLE
fix(deploy): add AUTH_DISABLED to Helm values example

### DIFF
--- a/deploy/helm/mortgage-ai/values.local.yaml.example
+++ b/deploy/helm/mortgage-ai/values.local.yaml.example
@@ -19,6 +19,7 @@ secrets:
   # VISION_API_KEY: ""
   COMPANY_NAME: ""
   AGENT_NAME: ""
+  AUTH_DISABLED: "true"
   MLFLOW_TRACKING_URI: ""
   MLFLOW_EXPERIMENT_NAME: ""          # e.g. "mortgage-ai"
   MLFLOW_WORKSPACE: ""                # e.g. "mortgage-ai" (auto-detected from pod namespace if empty)


### PR DESCRIPTION
## Summary
- Add `AUTH_DISABLED: "true"` to `values.local.yaml.example` so deployments can easily disable Keycloak authentication

## Test plan
- [ ] Verify `helm template` renders the secret correctly with AUTH_DISABLED set
- [ ] Confirm API starts with auth disabled when deployed with this value