### PR TITLE
feat(deploy): add kagenti.mlflow.autoManaged flag for Kagenti MLflow controller

### DIFF
--- a/deploy/helm/mortgage-ai/templates/api-deployment.yaml
+++ b/deploy/helm/mortgage-ai/templates/api-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         kagenti.io/outbound-ports-exclude: {{ .Values.kagenti.outboundPortsExclude | quote }}
       {{- end }}
     spec:
-      {{- if .Values.mlflow.rbac.enabled }}
+      {{- if and .Values.mlflow.rbac.enabled (not (dig "mlflow" "autoManaged" false .Values.kagenti)) }}
       serviceAccountName: {{ include "mortgage-ai.fullname" . }}-mlflow-client
       {{- else }}
       serviceAccountName: {{ include "mortgage-ai.serviceAccountName" . }}
@@ -262,6 +262,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mortgage-ai.fullname" . }}-secret
                   key: NEMO_GUARDRAILS_ENDPOINT
+            {{- if not (dig "mlflow" "autoManaged" false .Values.kagenti) }}
             - name: MLFLOW_TRACKING_URI
               valueFrom:
                 secretKeyRef:
@@ -287,6 +288,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mortgage-ai.fullname" . }}-secret
                   key: MLFLOW_TRACKING_INSECURE_TLS
+            {{- end }}
             - name: SQLADMIN_USER
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/mortgage-ai/templates/mlflow-rbac.yaml
+++ b/deploy/helm/mortgage-ai/templates/mlflow-rbac.yaml
@@ -1,5 +1,5 @@
 # This project was developed with assistance from AI tools.
-{{- if .Values.mlflow.rbac.enabled }}
+{{- if and .Values.mlflow.rbac.enabled (not (dig "mlflow" "autoManaged" false .Values.kagenti)) }}
 ---
 # MLflow integration ClusterRole for RHOAI 3.4+ MLflow server access.
 # This ClusterRole grants permissions to interact with MLflow CRDs

--- a/deploy/helm/mortgage-ai/templates/secret.yaml
+++ b/deploy/helm/mortgage-ai/templates/secret.yaml
@@ -63,11 +63,15 @@ data:
   {{- end }}
 
   # API -- MLflow observability
+  # When kagenti.mlflow.autoManaged=true, the Kagenti Operator injects these
+  # automatically via the kagenti.io/type=agent label on the Deployment.
+  {{- if not (dig "mlflow" "autoManaged" false .Values.kagenti) }}
   MLFLOW_TRACKING_URI: {{ .Values.secrets.MLFLOW_TRACKING_URI | toString | b64enc | quote }}
   MLFLOW_EXPERIMENT_NAME: {{ .Values.secrets.MLFLOW_EXPERIMENT_NAME | toString | b64enc | quote }}
   MLFLOW_WORKSPACE: {{ .Values.secrets.MLFLOW_WORKSPACE | toString | b64enc | quote }}
   MLFLOW_TRACKING_TOKEN: {{ .Values.secrets.MLFLOW_TRACKING_TOKEN | toString | b64enc | quote }}
   MLFLOW_TRACKING_INSECURE_TLS: {{ .Values.secrets.MLFLOW_TRACKING_INSECURE_TLS | toString | b64enc | quote }}
+  {{- end }}
 
   # API -- admin panel
   SQLADMIN_USER: {{ .Values.secrets.SQLADMIN_USER | toString | b64enc | quote }}

--- a/deploy/helm/mortgage-ai/values.yaml
+++ b/deploy/helm/mortgage-ai/values.yaml
@@ -214,8 +214,16 @@ minio:
       cpu: "500m"
 
 # MLflow observability (RHOAI 3.4+)
+# When kagenti.mlflow.autoManaged=true, the Kagenti Operator MLflow controller
+# handles MLflow automatically: auto-discovers MLflow from the
+# mlflows.mlflow.opendatahub.io CR, creates experiments, injects env vars,
+# and configures RBAC. Manual RBAC and env var configuration below is skipped.
+# Prerequisites for Kagenti-managed MLflow:
+#   1. Enable MLflow in the DataScienceCluster (RHOAI 3.4+)
+#   2. Install Kagenti with MLflow controller enabled
+#   3. Agents use mlflow[kubernetes]>=3.11 SDK
 mlflow:
-  # RBAC resources for MLflow server access
+  # RBAC resources for MLflow server access (skipped when kagenti.mlflow.autoManaged=true)
   rbac:
     enabled: true  # Enable when deploying with RHOAI MLflow
     # Creates: ClusterRole, ServiceAccount, ClusterRoleBinding
@@ -318,6 +326,11 @@ kagenti:
   a2aBasePort: 8080
   inboundPortsExclude: "8000"
   outboundPortsExclude: "5432,9000,8081"
+  # When true, delegate MLflow RBAC + env var injection to the Kagenti Operator
+  # MLflow controller. Requires Kagenti version with MLflow controller support.
+  # Keep false until the Kagenti MLflow controller is available in your cluster.
+  mlflow:
+    autoManaged: false
 
 # Seed data (demo data for demos / dev environments)
 seed:


### PR DESCRIPTION
## Summary
- Adds `kagenti.mlflow.autoManaged` flag (default: `false`) to control MLflow delegation to Kagenti Operator
- When `false` (default): manual MLflow RBAC, secrets, and env vars coexist safely with Kagenti A2A -- no behavior change from current deployments
- When `true`: skips manual MLflow resources, delegating to Kagenti Operator MLflow controller (auto-discovers MLflow from `mlflows.mlflow.opendatahub.io` CR, creates experiments, injects env vars, configures RBAC)
- Uses Helm `dig()` for nil-safe access -- avoids `--reuse-values` upgrade failures when existing releases lack the new nested key
- Supersedes #158 which incorrectly gated on `kagenti.enabled` (broke MLflow when Kagenti Operator v0.2.0-alpha.25 lacks the MLflow controller)

## Tested on cluster
- `kagenti.enabled=true`, `autoManaged=false` (default): MLflow env vars present, RBAC created, pod 3/3 Running
- `kagenti.enabled=true`, `autoManaged=true`: MLflow env vars absent, no RBAC -- ready for Kagenti MLflow controller
- `helm upgrade --reuse-values` succeeds without the new key in existing values

## Test plan
- [x] `helm template` with default values produces MLflow config
- [x] `helm template` with `kagenti.mlflow.autoManaged=true` produces no MLflow config
- [x] `helm upgrade --reuse-values` on existing release (no nil pointer errors)
- [x] Deployed to team1 namespace -- API pod healthy with MLflow tracing active

Generated with [Claude Code](https://claude.com/claude-code)