### PR TITLE
fix(evaluations): append /mlflow path to MLflow tracking URI

### DIFF
--- a/evaluations/evaluate_agent.ipynb
+++ b/evaluations/evaluate_agent.ipynb
@@ -53,7 +53,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import os\n\n# -- Set your environment variables here --\nos.environ[\"LLM_BASE_URL\"] = \"https://litellm-prod.apps.maas.redhatworkshops.io\"\nos.environ[\"LLM_API_KEY\"] = \"\"\nos.environ[\"LLM_MODEL\"] = \"gpt-oss-120b\"\nos.environ[\"MLFLOW_TRACKING_URI\"] = \"https://mlflow.redhat-ods-applications.svc.cluster.local:8443\"\nos.environ[\"MLFLOW_EXPERIMENT_NAME\"] = \"mortgage-ai-eval\"\nos.environ[\"MLFLOW_TRACKING_AUTH\"] = \"kubernetes\"\nos.environ[\"MLFLOW_TRACKING_INSECURE_TLS\"] = \"true\"\nos.environ[\"MLFLOW_TRACKING_TOKEN\"] = \"\"  # or run: export MLFLOW_TRACKING_TOKEN=$(oc whoami --show-token)"
+   "source": [
+    "import os\n",
+    "\n",
+    "# -- Set your environment variables here --\n",
+    "os.environ[\"LLM_BASE_URL\"] = \"https://litellm-prod.apps.maas.redhatworkshops.io\"\n",
+    "os.environ[\"LLM_API_KEY\"] = \"\"\n",
+    "os.environ[\"LLM_MODEL\"] = \"gpt-oss-120b\"\n",
+    "os.environ[\"MLFLOW_TRACKING_URI\"] = \"https://mlflow.redhat-ods-applications.svc.cluster.local:8443/mlflow\"\n",
+    "os.environ[\"MLFLOW_EXPERIMENT_NAME\"] = \"mortgage-ai-eval\"\n",
+    "os.environ[\"MLFLOW_TRACKING_AUTH\"] = \"kubernetes\"\n",
+    "os.environ[\"MLFLOW_TRACKING_INSECURE_TLS\"] = \"true\"\n",
+    "os.environ[\"MLFLOW_TRACKING_TOKEN\"] = \"\"  # or run: export MLFLOW_TRACKING_TOKEN=$(oc whoami --show-token)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/evaluations/evaluate_agent_v2.ipynb
+++ b/evaluations/evaluate_agent_v2.ipynb
@@ -48,7 +48,7 @@
     "os.environ[\"LLM_BASE_URL\"] = \"https://litellm-prod.apps.maas.redhatworkshops.io\"\n",
     "os.environ[\"LLM_API_KEY\"] = \"\"\n",
     "os.environ[\"LLM_MODEL\"] = \"gpt-oss-120b\"\n",
-    "os.environ[\"MLFLOW_TRACKING_URI\"] = \"https://mlflow.redhat-ods-applications.svc.cluster.local:8443\"\n",
+    "os.environ[\"MLFLOW_TRACKING_URI\"] = \"https://mlflow.redhat-ods-applications.svc.cluster.local:8443/mlflow\"\n",
     "os.environ[\"MLFLOW_EXPERIMENT_NAME\"] = \"mortgage-ai-eval\"\n",
     "os.environ[\"MLFLOW_TRACKING_AUTH\"] = \"kubernetes\"\n",
     "os.environ[\"MLFLOW_TRACKING_INSECURE_TLS\"] = \"true\"\n",


### PR DESCRIPTION
## Summary
- Fixes 404 error when evaluation notebooks call `mlflow.set_experiment()` against the RHOAI MLflow server
- The internal service URL (`mlflow.redhat-ods-applications.svc.cluster.local:8443`) requires the `/mlflow` path prefix to reach the REST API
- Applied to both `evaluate_agent.ipynb` and `evaluate_agent_v2.ipynb`

## Test plan
- [ ] Run cell 6 in `evaluations/evaluate_agent.ipynb` — `mlflow.set_experiment()` should succeed
- [ ] Run cell 6 in `evaluations/evaluate_agent_v2.ipynb` — same check
- [ ] Verify full evaluation run completes without MLflow connection errors