### PR TITLE
fix(deploy): fix nemo guardrails proxy rewrite and add GPU tolerations

### DIFF
--- a/deploy/helm/mortgage-ai/templates/nemo-guardrails-model.yaml
+++ b/deploy/helm/mortgage-ai/templates/nemo-guardrails-model.yaml
@@ -79,6 +79,10 @@ spec:
   predictor:
     maxReplicas: 1
     minReplicas: 1
+    {{- with .Values.nemoGuardrails.contentSafety.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     model:
       modelFormat:
         name: vLLM

--- a/deploy/helm/mortgage-ai/templates/nemo-guardrails-proxy.yaml
+++ b/deploy/helm/mortgage-ai/templates/nemo-guardrails-proxy.yaml
@@ -27,8 +27,10 @@ data:
         listen 8081;
         location / {
           set $upstream {{ .Values.nemoGuardrails.proxy.maas.upstream }};
+          {{- if .Values.nemoGuardrails.proxy.maas.pathPrefix }}
           rewrite ^/v1/(.*)$ /{{ .Values.nemoGuardrails.proxy.maas.pathPrefix }}/v1/$1 break;
           rewrite ^/tokenize$ /{{ .Values.nemoGuardrails.proxy.maas.pathPrefix }}/tokenize break;
+          {{- end }}
           proxy_pass $upstream;
           proxy_http_version 1.1;
           proxy_ssl_server_name on;


### PR DESCRIPTION
## Summary
- Skip nginx rewrite rules when `pathPrefix` is empty to avoid double-slash URLs in proxy requests
- Add `tolerations` support to the content safety InferenceService predictor for GPU node scheduling

## Test plan
- [ ] Deploy with empty `pathPrefix` and verify proxy passes requests without rewrite
- [ ] Deploy with `pathPrefix` set and verify rewrite still works
- [ ] Deploy content safety model on a cluster with GPU tolerations configured