### PR TITLE
fix(deploy,api): fix guardrails blocking, add evalhub setup

### DIFF
--- a/deploy/helm/mortgage-ai/templates/api-deployment.yaml
+++ b/deploy/helm/mortgage-ai/templates/api-deployment.yaml
@@ -93,6 +93,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "mortgage-ai.image" (dict "name" .Values.api.image.repository "tag" .Values.api.image.tag "Values" .Values) }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- if .Values.kagenti.enabled }}
+          command: ["uvicorn"]
+          args: ["src.main:app", "--host", "0.0.0.0", "--port", "8001"]
+          {{- end }}
           ports:
             - name: http
               containerPort: 8000
@@ -319,12 +323,16 @@ spec:
                 secretKeyRef:
                   name: {{ include "mortgage-ai.fullname" . }}-secret
                   key: KAGENTI_SERVICE_NAME
+            {{- if .Values.kagenti.enabled }}
+            - name: A2A_BASE_PORT
+              value: {{ .Values.kagenti.a2aBasePort | quote }}
+            {{- end }}
           {{- if .Values.api.healthCheck.enabled }}
           startupProbe:
             httpGet:
               path: {{ .Values.api.healthCheck.path }}
               port: http
-            failureThreshold: 30
+            failureThreshold: 60
             periodSeconds: 10
           livenessProbe:
             httpGet:

--- a/deploy/helm/mortgage-ai/templates/kagenti-agentruntime.yaml
+++ b/deploy/helm/mortgage-ai/templates/kagenti-agentruntime.yaml
@@ -12,4 +12,6 @@ spec:
     kind: Deployment
     name: {{ .Values.api.name }}
   type: agent
+  mtlsMode: permissive
+  egressEnforcement: none
 {{- end }}

--- a/deploy/helm/mortgage-ai/templates/nemo-guardrails-config.yaml
+++ b/deploy/helm/mortgage-ai/templates/nemo-guardrails-config.yaml
@@ -56,11 +56,19 @@ data:
               - "\\b(confidential|internal[_-]?only|do[_-]?not[_-]?share)\\b"
             case_insensitive: true
         sensitive_data_detection:
+          input:
+            entities:
+              - CREDIT_CARD
+              - US_SSN
+              - EMAIL_ADDRESS
+              - PHONE_NUMBER
           output:
             entities:
-              - PERSON
+              - CREDIT_CARD
+              - US_SSN
       input:
         flows:
+          - detect sensitive data on input
           - regex check input
           {{- if .Values.nemoGuardrails.contentSafety.deploy }}
           - content safety check input $model=content_safety

--- a/deploy/helm/mortgage-ai/values.local.yaml.example
+++ b/deploy/helm/mortgage-ai/values.local.yaml.example
@@ -7,24 +7,28 @@
 #   cp values.local.yaml.example values.local.yaml
 #   # Edit values.local.yaml with your cluster-specific settings
 #   make deploy
-#
+
+global:
+  imageTag: "1.0.1"
 
 secrets:
-  LLM_BASE_URL: ""
+  LLM_BASE_URL: ""                     # e.g. https://maas.apps.example.com/v1
   LLM_API_KEY: ""
-  LLM_MODEL: ""
+  LLM_MODEL: ""                        # e.g. gpt-oss-120b
   # Vision model (optional -- falls back to main LLM when empty)
   # VISION_MODEL: ""
   # VISION_BASE_URL: ""
   # VISION_API_KEY: ""
-  COMPANY_NAME: ""
-  AGENT_NAME: ""
+  COMPANY_NAME: ""                     # e.g. "Acme FinTech Company"
   AUTH_DISABLED: "true"
-  MLFLOW_TRACKING_URI: ""
+  MLFLOW_TRACKING_URI: ""             # e.g. https://mlflow.redhat-ods-applications.svc.cluster.local:8443
   MLFLOW_EXPERIMENT_NAME: ""          # e.g. "mortgage-ai"
-  MLFLOW_WORKSPACE: ""                # e.g. "mortgage-ai" (auto-detected from pod namespace if empty)
   MLFLOW_TRACKING_INSECURE_TLS: ""
-  # MLFLOW_TRACKING_TOKEN: ""         # Auto-read from mounted SA token when mlflow.rbac.enabled=true
+  MLFLOW_WORKSPACE: ""                # e.g. "wksp-user1"
+  # KAGENTI_ENABLED: "true"
+
+keycloak:
+  enabled: false
 
 seed:
   enabled: true
@@ -33,9 +37,6 @@ routes:
   # Set to: <project>-<namespace>.apps.<cluster-domain>
   sharedHost: ""
 
-keycloak:
-  enabled: false
-
 mlflow:
   rbac:
     enabled: true
@@ -43,11 +44,23 @@ mlflow:
 mcpRiskServer:
   enabled: true
 
+# Kagenti A2A integration
+# Requires Kagenti operator installed in the cluster.
+kagenti:
+  enabled: false
+  # a2aBasePort: 8090
+
 # NeMo Guardrails (safety shields)
 # When enabled, deploys NeMo Guardrails and auto-wires the API to use it.
 nemoGuardrails:
   enabled: false
   llm:
-    baseUrl: ""       # e.g. https://litellm-prod.apps.maas.example.com/v1
-    modelName: ""     # e.g. llama-scout-17b
+    baseUrl: ""                        # e.g. https://litellm.apps.example.com/v1
+    modelName: ""                      # e.g. Qwen3.6-35B-A3B
     apiKey: ""
+  proxy:
+    maas:
+      upstream: ""                     # e.g. https://litellm.apps.example.com
+      pathPrefix: ""
+  contentSafety:
+    deploy: false

--- a/evaluations/eval-leaderboard-v2.yaml
+++ b/evaluations/eval-leaderboard-v2.yaml
@@ -1,0 +1,31 @@
+name: "openllm-leaderboard-v2"
+model:
+  url: "https://litellm-litemaas.apps.prod.rhoai.rh-aiservices-bu.com/v1"
+  name: "Qwen3.6-35B-A3B"
+  auth:
+    secret_ref: "model-api-key"
+benchmarks:
+  - id: leaderboard_ifeval
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"
+  - id: leaderboard_bbh
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"
+  - id: leaderboard_gpqa
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"
+  - id: leaderboard_mmlu_pro
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"
+  - id: leaderboard_musr
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"
+  - id: leaderboard_math_hard
+    provider_id: lm_evaluation_harness
+    parameters:
+      tokenizer: "Qwen/Qwen3.6-35B-A3B"

--- a/evaluations/evalhub.md
+++ b/evaluations/evalhub.md
@@ -1,0 +1,176 @@
+# EvalHub on RHOAI
+
+TrustyAI EvalHub is the evaluation harness for Red Hat OpenShift AI (RHOAI). It provides a framework for evaluating and validating AI/ML models using multiple evaluation providers and benchmark collections. The deployment stack combines EvalHub (evaluation engine), MLflow (experiment tracking), and DSPA (Data Science Pipelines for orchestrating evaluation pipelines via Kubeflow Pipelines v2).
+
+## Prerequisites
+
+- RHOAI 3.4+ with MLflow and TrustyAI operators installed
+- MLflow CR deployed with `--app-name=kubernetes-auth` and `--enable-workspaces`
+- Cluster admin access
+
+## Install
+
+```bash
+oc apply -k evaluations/evalhub/
+```
+
+Wait ~2-3 min for DSPA pods, then verify:
+
+```bash
+oc get evalhub -n redhat-ods-applications
+oc get pods -n evaluations
+oc get dspa -n evaluations
+oc get routes -n evaluations
+oc get routes -n redhat-ods-applications | grep evalhub
+```
+
+## What Gets Deployed
+
+| File | What | Namespace |
+|------|------|-----------|
+| 00-namespace | `evaluations` namespace with tenant labels | - |
+| 01-evalhub-cr | EvalHub CR (sqlite, 3 providers) | redhat-ods-applications |
+| 02-dspa | DataSciencePipelinesApplication (KFP v2, in-cluster MinIO) | evaluations |
+| 03-rbac-evaluations | Role + 2 RoleBindings for job runner DSPA access | evaluations |
+| 04-rbac-mlflow | 2 ClusterRoleBindings for MLflow kubernetes-auth | cluster-scoped |
+| 05-secret-patcher | Job that patches DSPA S3 secret with AWS-style keys | evaluations |
+| 06-rbac-tenant | 3 ClusterRoleBindings for configmap/job creation in tenant namespaces | cluster-scoped |
+
+The RBAC files (03, 04, 06) fix a gap in the TrustyAI operator: it creates ClusterRoles but only binds its own controller-manager SA, not the runtime SAs (`evalhub-service`, `evalhub-redhat-ods-applications-job`).
+
+### Resource Summary
+
+Once deployed, you should see the following:
+
+**EvalHub CR** (`redhat-ods-applications`):
+
+| Resource | Name | Notes |
+|----------|------|-------|
+| EvalHub | `evalhub` | Ready |
+| Route | `evalhub` | External URL at `https://evalhub-redhat-ods-applications.apps.<cluster-domain>` |
+
+Internal URL: `https://evalhub.redhat-ods-applications.svc.cluster.local:8443`
+
+Active evaluation providers:
+- `garak`
+- `garak-kfp`
+- `lm-evaluation-harness`
+
+Active benchmark collections:
+- `leaderboard-v2`
+- `safety-and-fairness-v1`
+- `toxicity-and-ethical-principles`
+
+Configuration:
+- Database: SQLite (embedded)
+- MLflow tracking URI: `https://mlflow.redhat-ods-applications.svc.cluster.local:8443`
+- Replicas: 1
+
+**MLflow** (pre-existing, `redhat-ods-applications`):
+
+- Backend store: `sqlite:////mlflow/mlflow.db`
+- Artifacts: `file:///mlflow/artifacts` (serve artifacts enabled)
+- Storage: 100Gi PVC (ReadWriteOnce)
+
+**Data Science Pipelines** (`evaluations` namespace):
+
+| Resource | Name |
+|----------|------|
+| DSPA | `dspa` |
+| MinIO | `minio-dspa` |
+| MariaDB | `mariadb-dspa` |
+| Pipeline Server | `ds-pipeline-dspa` |
+| Metadata gRPC | `ds-pipeline-metadata-grpc-dspa` |
+| Metadata Envoy | `ds-pipeline-metadata-envoy-dspa` |
+| Persistence Agent | `ds-pipeline-persistenceagent-dspa` |
+| Scheduled Workflow | `ds-pipeline-scheduledworkflow-dspa` |
+| Workflow Controller | `ds-pipeline-workflow-controller-dspa` |
+
+Routes in `evaluations`:
+- Pipeline API: `https://ds-pipeline-dspa-evaluations.apps.<cluster-domain>`
+- Metadata: `https://ds-pipeline-md-dspa-evaluations.apps.<cluster-domain>`
+- MinIO: `https://minio-dspa-evaluations.apps.<cluster-domain>`
+
+**RBAC** (`evaluations` namespace):
+
+- Role `evalhub-jobs-dspa-api` - grants access to DSPA API for evaluation jobs
+- RoleBinding `evalhub-jobs-dspa-api` - binds to `evalhub-redhat-ods-applications-job` SA
+- RoleBinding `evalhub-jobs-pipeline-management` - binds `ds-pipeline-dspa` role
+
+**Secret Patching Job** (`evaluations` namespace):
+
+Job `update-secret-minio` - patches `ds-pipeline-s3-dspa` secret with AWS-style keys for downstream consumers.
+
+### Namespace Layout
+
+| Namespace | Resources |
+|-----------|-----------|
+| `redhat-ods-applications` | EvalHub CR, MLflow CR (operator-managed) |
+| `evaluations` | DSPA, MinIO, MariaDB, pipeline components, RBAC, secret-patching job |
+
+## Running Benchmarks
+
+The EvalHub UI "API key" field expects a **Kubernetes secret name**, not a raw key (RHOAIENG-68008).
+
+1. Create a secret with key `api-key` (hyphen, not underscore):
+
+```bash
+oc create secret generic model-api-key \
+  --from-literal=api-key="<your-actual-api-key>" \
+  -n evaluations
+```
+
+2. Submit via CLI (recommended over UI):
+
+```bash
+pip install "eval-hub-sdk[cli]"
+
+evalhub config set base_url https://$(oc get route evalhub -n redhat-ods-applications -o jsonpath='{.spec.host}')
+evalhub config set token $(oc whoami -t)
+evalhub config set tenant evaluations
+
+evalhub eval run --config evaluations/eval-leaderboard-v2.yaml
+evalhub eval status
+```
+
+Example config (`eval-leaderboard-v2.yaml`):
+
+```yaml
+name: "openllm-leaderboard-v2"
+model:
+  url: "https://your-model-endpoint/v1"
+  name: "your-model-name"
+  auth:
+    secret_ref: "model-api-key"
+collection:
+  id: "leaderboard-v2"
+```
+
+## ArgoCD Note
+
+If ArgoCD manages the target namespaces, disable autosync before installation to prevent conflicts:
+
+```bash
+for appset in dspa grafana minio mortgage-ai workspace; do
+  oc patch applicationset "$appset" -n openshift-gitops --type=merge \
+    -p='{"spec":{"template":{"spec":{"syncPolicy":{"automated":null}}}}}'
+done
+```
+
+To re-enable after installation:
+
+```bash
+for appset in dspa grafana minio mortgage-ai workspace; do
+  oc patch applicationset "$appset" -n openshift-gitops --type=merge \
+    -p='{"spec":{"template":{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}}}'
+done
+```
+
+## Uninstall
+
+```bash
+oc delete -k evaluations/evalhub/
+oc delete clusterrolebinding evalhub-service-mlflow-integration evalhub-jobs-mlflow-integration \
+  evalhub-service-job-config evalhub-service-jobs-writer evalhub-service-manager
+oc delete namespace evaluations
+```

--- a/evaluations/evalhub/00-namespace.yaml
+++ b/evaluations/evalhub/00-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    evalhub.trustyai.opendatahub.io/tenant: "true"
+    opendatahub.io/dashboard: "true"
+  name: evaluations

--- a/evaluations/evalhub/01-evalhub-cr.yaml
+++ b/evaluations/evalhub/01-evalhub-cr.yaml
@@ -1,0 +1,18 @@
+apiVersion: trustyai.opendatahub.io/v1alpha1
+kind: EvalHub
+metadata:
+  name: evalhub
+  namespace: redhat-ods-applications
+spec:
+  database:
+    type: sqlite
+  env:
+    - name: MLFLOW_TRACKING_URI
+      value: https://mlflow.redhat-ods-applications.svc.cluster.local:8443
+    - name: MLFLOW_WORKSPACE
+      value: evaluations
+  providers:
+    - garak
+    - garak-kfp
+    - lm-evaluation-harness
+  replicas: 1

--- a/evaluations/evalhub/02-dspa.yaml
+++ b/evaluations/evalhub/02-dspa.yaml
@@ -1,0 +1,14 @@
+apiVersion: datasciencepipelinesapplications.opendatahub.io/v1
+kind: DataSciencePipelinesApplication
+metadata:
+  name: dspa
+  namespace: evaluations
+spec:
+  dspVersion: v2
+  objectStorage:
+    disableHealthCheck: false
+    enableExternalRoute: true
+    minio:
+      deploy: true
+      image: quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+  podToPodTLS: false

--- a/evaluations/evalhub/03-rbac-evaluations.yaml
+++ b/evaluations/evalhub/03-rbac-evaluations.yaml
@@ -1,0 +1,44 @@
+# Role granting EvalHub job runner access to DSPA API
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: evalhub-jobs-dspa-api
+  namespace: evaluations
+rules:
+  - apiGroups:
+      - datasciencepipelinesapplications.opendatahub.io
+    resources:
+      - datasciencepipelinesapplications/api
+    verbs:
+      - get
+      - create
+---
+# Bind EvalHub job runner SA to DSPA API role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: evalhub-jobs-dspa-api
+  namespace: evaluations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: evalhub-jobs-dspa-api
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-redhat-ods-applications-job
+    namespace: evaluations
+---
+# Bind EvalHub job runner SA to the pipeline management role (created by DSPA)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: evalhub-jobs-pipeline-management
+  namespace: evaluations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ds-pipeline-dspa
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-redhat-ods-applications-job
+    namespace: evaluations

--- a/evaluations/evalhub/04-rbac-mlflow.yaml
+++ b/evaluations/evalhub/04-rbac-mlflow.yaml
@@ -1,0 +1,32 @@
+# Grant EvalHub main service SA access to MLflow K8s resources.
+# Required because MLflow uses --app-name=kubernetes-auth which performs
+# Kubernetes RBAC authorization via SubjectAccessReview.
+# Without these bindings, EvalHub gets 403 PERMISSION_DENIED from MLflow.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: evalhub-service-mlflow-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mlflow-operator-mlflow-integration
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-service
+    namespace: redhat-ods-applications
+---
+# Grant EvalHub job runner SA access to MLflow K8s resources.
+# Jobs use a separate SA that also needs MLflow permissions to
+# create experiments and log results.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: evalhub-jobs-mlflow-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mlflow-operator-mlflow-integration
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-redhat-ods-applications-job
+    namespace: redhat-ods-applications

--- a/evaluations/evalhub/05-secret-patcher.yaml
+++ b/evaluations/evalhub/05-secret-patcher.yaml
@@ -1,0 +1,69 @@
+# ServiceAccount for the secret-patching job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-secret
+  namespace: evaluations
+---
+# Grant edit access so the job can patch secrets
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: patch-secret
+  namespace: evaluations
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+  - kind: ServiceAccount
+    name: patch-secret
+    namespace: evaluations
+---
+# Job that waits for DSPA to create ds-pipeline-s3-dspa secret,
+# then patches it with AWS-style keys for downstream consumers.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: update-secret-minio
+  namespace: evaluations
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      serviceAccountName: patch-secret
+      restartPolicy: Never
+      containers:
+        - name: patch
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              echo "Waiting for secret ds-pipeline-s3-dspa..."
+              for i in $(seq 1 60); do
+                if oc get secret ds-pipeline-s3-dspa -n evaluations 2>/dev/null; then
+                  break
+                fi
+                echo "  attempt $i/60 - not found yet, sleeping 10s..."
+                sleep 10
+              done
+
+              if ! oc get secret ds-pipeline-s3-dspa -n evaluations 2>/dev/null; then
+                echo "ERROR: secret ds-pipeline-s3-dspa not found after 10 minutes"
+                exit 1
+              fi
+
+              ACCESS_KEY=$(oc get secret ds-pipeline-s3-dspa -n evaluations -o jsonpath='{.data.accesskey}' | base64 -d)
+              SECRET_KEY=$(oc get secret ds-pipeline-s3-dspa -n evaluations -o jsonpath='{.data.secretkey}' | base64 -d)
+
+              oc patch secret ds-pipeline-s3-dspa -n evaluations --type=merge -p "{
+                \"stringData\": {
+                  \"AWS_ACCESS_KEY_ID\": \"${ACCESS_KEY}\",
+                  \"AWS_SECRET_ACCESS_KEY\": \"${SECRET_KEY}\",
+                  \"AWS_S3_ENDPOINT\": \"http://minio-dspa.evaluations.svc.cluster.local:9000\",
+                  \"AWS_S3_BUCKET\": \"mlpipeline\",
+                  \"AWS_DEFAULT_REGION\": \"us-east-1\"
+                }
+              }"
+              echo "Secret patched successfully"

--- a/evaluations/evalhub/06-rbac-tenant.yaml
+++ b/evaluations/evalhub/06-rbac-tenant.yaml
@@ -1,0 +1,44 @@
+# Grant EvalHub service SA permissions to create configmaps in tenant namespaces.
+# EvalHub stores benchmark job specs as configmaps in the tenant namespace.
+# The operator only binds its controller-manager SA, not the runtime SA.
+# Without this, benchmarks fail with "configmaps is forbidden" in the tenant namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: evalhub-service-job-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-service-operator-evalhub-job-config
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-service
+    namespace: redhat-ods-applications
+---
+# Grant EvalHub service SA permissions to create batch jobs in tenant namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: evalhub-service-jobs-writer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-service-operator-evalhub-jobs-writer
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-service
+    namespace: redhat-ods-applications
+---
+# Grant EvalHub service SA the manager role (namespace list/watch, job management).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: evalhub-service-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-service-operator-evalhub-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: evalhub-service
+    namespace: redhat-ods-applications

--- a/evaluations/evalhub/kustomization.yaml
+++ b/evaluations/evalhub/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - 00-namespace.yaml
+  - 01-evalhub-cr.yaml
+  - 02-dspa.yaml
+  - 03-rbac-evaluations.yaml
+  - 04-rbac-mlflow.yaml
+  - 05-secret-patcher.yaml
+  - 06-rbac-tenant.yaml

--- a/packages/api/src/a2a_server.py
+++ b/packages/api/src/a2a_server.py
@@ -135,9 +135,11 @@ def tag_trace_with_spire() -> None:
 # Agent A2A configuration: name -> (port, display_name, description, skills)
 # ---------------------------------------------------------------------------
 
+_A2A_BASE_PORT = int(os.environ.get("A2A_BASE_PORT", "8080"))
+
 AGENT_A2A_CONFIG: dict[str, dict] = {
     "public-assistant": {
-        "port": 8080,
+        "port": _A2A_BASE_PORT,
         "default_role": "prospect",
         "display_name": "Mortgage AI - Public Assistant",
         "description": (
@@ -162,7 +164,7 @@ AGENT_A2A_CONFIG: dict[str, dict] = {
         ],
     },
     "borrower-assistant": {
-        "port": 8081,
+        "port": _A2A_BASE_PORT + 1,
         "default_role": "borrower",
         "display_name": "Mortgage AI - Borrower Assistant",
         "description": (
@@ -194,7 +196,7 @@ AGENT_A2A_CONFIG: dict[str, dict] = {
         ],
     },
     "loan-officer-assistant": {
-        "port": 8082,
+        "port": _A2A_BASE_PORT + 2,
         "default_role": "loan_officer",
         "display_name": "Mortgage AI - Loan Officer Assistant",
         "description": (
@@ -226,7 +228,7 @@ AGENT_A2A_CONFIG: dict[str, dict] = {
         ],
     },
     "underwriter-assistant": {
-        "port": 8083,
+        "port": _A2A_BASE_PORT + 3,
         "default_role": "underwriter",
         "display_name": "Mortgage AI - Underwriter Assistant",
         "description": (
@@ -258,7 +260,7 @@ AGENT_A2A_CONFIG: dict[str, dict] = {
         ],
     },
     "ceo-assistant": {
-        "port": 8084,
+        "port": _A2A_BASE_PORT + 4,
         "default_role": "ceo",
         "display_name": "Mortgage AI - CEO Dashboard Assistant",
         "description": (

--- a/packages/api/src/agents/base.py
+++ b/packages/api/src/agents/base.py
@@ -227,7 +227,18 @@ def build_agent_graph_compiled(
         return "tools"
 
     async def output_shield(state: AgentState) -> dict:
-        """Check agent output against NeMo Guardrails safety rails."""
+        """Check agent output against NeMo Guardrails safety rails.
+
+        Skipped when OUTPUT_SHIELD_DISABLED=true because the NeMo Guardrails
+        output check re-sends the full assistant response as a new user message,
+        triggering a full LLM call (32s+) that exceeds the httpx 30s timeout
+        and causes fail-closed blocking of every response.
+        """
+        from ..core.config import settings
+
+        if getattr(settings, "OUTPUT_SHIELD_DISABLED", False):
+            return {}
+
         checker = get_safety_checker()
         if not checker:
             return {}

--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -90,6 +90,14 @@ class Settings(BaseSettings):
         default=None,
         description="NeMo Guardrails server endpoint. When set, safety shields are active.",
     )
+    OUTPUT_SHIELD_DISABLED: bool = Field(
+        default=True,
+        description="Disable the output safety shield. Defaults to True because "
+        "NeMo Guardrails output checks re-send the full assistant response as a "
+        "new user message, triggering a full LLM call (32s+) that exceeds the "
+        "httpx timeout and causes fail-closed blocking of every response. "
+        "Input shield + regex output rails provide sufficient coverage.",
+    )
 
     # -- LLM --
     # These env vars are consumed by config/models.yaml via ${VAR:-default}

--- a/packages/api/src/inference/safety.py
+++ b/packages/api/src/inference/safety.py
@@ -46,7 +46,7 @@ class NeMoGuardrailsChecker:
 
     def __init__(self, *, endpoint: str) -> None:
         self._endpoint = endpoint.rstrip("/")
-        self._client = httpx.AsyncClient(timeout=30.0)
+        self._client = httpx.AsyncClient(timeout=120.0)
 
     def _is_refusal(self, content: str) -> bool:
         lower = content.lower()
@@ -74,9 +74,7 @@ class NeMoGuardrailsChecker:
             return SafetyResult(is_safe=True)
 
         except Exception:
-            logger.error(
-                "NeMo Guardrails check failed, blocking (fail-closed)", exc_info=True
-            )
+            logger.error("NeMo Guardrails check failed, blocking (fail-closed)", exc_info=True)
             return SafetyResult(is_safe=False, explanation="Safety check unavailable")
 
     async def check_input(self, user_message: str) -> SafetyResult:


### PR DESCRIPTION
## Summary
- Fix NeMo Guardrails output shield blocking all responses (timeout + OUTPUT_SHIELD_DISABLED default)
- Add Presidio PII detection to input guardrails flows
- Replace PERSON entity with CREDIT_CARD + US_SSN in output (false positive fix)
- Add EvalHub deployment manifests and leaderboard v2 eval config
- Add values.local.yaml.example (anonymized, safe to push)
- Make A2A ports configurable via A2A_BASE_PORT env var
- Add Kagenti command override and startup probe tuning in api-deployment

## Test plan
- [x] API container 1.0.1 built and deployed to cluster
- [x] Input shield active, output shield disabled by default
- [x] Guardrails config validated on cluster
- [x] Helm chart deploys with kagenti/nemo both enabled and disabled