### PR TITLE
fix(api): enable output shield by default

### DIFF
--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -91,12 +91,10 @@ class Settings(BaseSettings):
         description="NeMo Guardrails server endpoint. When set, safety shields are active.",
     )
     OUTPUT_SHIELD_DISABLED: bool = Field(
-        default=True,
-        description="Disable the output safety shield. Defaults to True because "
-        "NeMo Guardrails output checks re-send the full assistant response as a "
-        "new user message, triggering a full LLM call (32s+) that exceeds the "
-        "httpx timeout and causes fail-closed blocking of every response. "
-        "Input shield + regex output rails provide sufficient coverage.",
+        default=False,
+        description="Disable the output safety shield. Now defaults to False "
+        "because the /v1/guardrail/checks endpoint runs only rails without "
+        "triggering a full LLM call, completing in <1s.",
     )
 
     # -- LLM --


### PR DESCRIPTION
## Summary

- Flips `OUTPUT_SHIELD_DISABLED` default from `True` to `False` in config.py
- The output shield was disabled because the old `/v1/chat/completions` endpoint triggered a full LLM call (32s+) on every response check
- PR #182 switched to `/v1/guardrail/checks` which runs only rails (<1s) - so the output shield is now safe to enable
- Tested end-to-end on `wksp-user1`: both shields on, first token ~3s, total ~11s - no added latency

## Test plan

- [x] Deployed with `OUTPUT_SHIELD_DISABLED=false` on wksp-user1
- [x] Sent chat message through UI - response time unchanged (~11s total)
- [x] Output shield runs without blocking legitimate responses