### PR TITLE
Handle non-streaming LLM responses and add LLM_STREAMING toggle

### DIFF
--- a/packages/api/src/agents/base.py
+++ b/packages/api/src/agents/base.py
@@ -367,6 +367,7 @@ def build_agent_graph(
         model=model_cfg["model_name"],
         base_url=model_cfg["endpoint"],
         api_key=model_cfg.get("api_key", "not-needed"),
+        streaming=Settings().LLM_STREAMING,
     )
 
     return build_agent_graph_compiled(

--- a/packages/api/src/core/config.py
+++ b/packages/api/src/core/config.py
@@ -113,6 +113,11 @@ class Settings(BaseSettings):
         default="gpt-4o-mini",
         description="Model name for the primary LLM.",
     )
+    LLM_STREAMING: bool = Field(
+        default=True,
+        description="Enable streaming for LLM calls. Disable when the inference "
+        "proxy does not support reliable streaming (e.g. LiteMaaS).",
+    )
 
     # -- Vision model (optional, falls back to main LLM when unset) --
     VISION_MODEL: str | None = Field(

--- a/packages/api/src/routes/_chat_handler.py
+++ b/packages/api/src/routes/_chat_handler.py
@@ -199,6 +199,15 @@ async def run_agent_stream(
                 if isinstance(chunk, AIMessageChunk) and chunk.content:
                     full_response += chunk.content
 
+            elif kind == "on_chat_model_end" and node in (
+                "agent",
+                "agent_fast",
+                "agent_capable",
+            ):
+                output = event.get("data", {}).get("output")
+                if isinstance(output, AIMessage) and output.content and not full_response:
+                    full_response = output.content
+
             elif kind == "on_chain_end" and node == "input_shield":
                 output = event.get("data", {}).get("output")
                 if isinstance(output, dict) and output.get("safety_blocked"):


### PR DESCRIPTION
## Summary

- Add `on_chat_model_end` event handler to `_chat_handler.py` so chat responses are captured when the LLM is called in non-streaming mode (previously only `on_chat_model_stream` was handled, silently dropping the response content)
- Add `LLM_STREAMING` env var (default `true`) to `Settings` so deployments can disable streaming without rebuilding the image
- Wire `ChatOpenAI(streaming=...)` in `base.py` to the new setting

## Context

When deployed behind LiteMaaS with model `gpt-oss-120b`, the streaming proxy returns `503 ServiceUnavailableError` (dead upstream route) and `429 RateLimitError` on ~90% of streaming requests. Non-streaming requests succeed 100%. This causes the Mortgage AI chat to display "Our chat assistant is temporarily unavailable" on every attempt.

Setting `LLM_STREAMING=false` fully resolves the issue. The `on_chat_model_end` handler is needed regardless -- without it, disabling streaming produces empty chat responses because the existing code only accumulates content from `on_chat_model_stream` events.

## Test plan

- [ ] Verify chat works with `LLM_STREAMING=true` (default, OpenAI endpoints)
- [ ] Verify chat works with `LLM_STREAMING=false` (LiteMaaS / unreliable streaming proxies)
- [ ] Verify safety shields still fire in both modes
- [ ] Verify tool-calling agents (borrower, LO, UW) still invoke tools correctly in non-streaming mode